### PR TITLE
Fix: Chrome spawn issues for non-headless mode on Linux servers with DISPLAY

### DIFF
--- a/bin/launch.mjs
+++ b/bin/launch.mjs
@@ -76,6 +76,7 @@ const BASE_CHROME_FLAGS = [
 	"--window-size=1920,1080",
 	"--lang=en-US",
 	"--force-color-profile=srgb",
+	"--no-sandbox",
 ];
 
 function getChromeVersion(chromePath) {
@@ -415,17 +416,17 @@ async function main() {
 	}
 
 	const proc = spawn(CHROME_EXE, buildChromeFlags(CHROME_EXE), {
-		detached: true,
-		stdio: "ignore",
+		env: process.env,
+		stdio: ["ignore", "pipe", "pipe"],
 	});
-	proc.unref();
+	proc.stderr.on("data", (d) => process.stderr.write(d));
 	writeFileSync(PID_FILE, String(proc.pid));
 	// Write mode marker so ensureChrome() can detect headless vs visible
 	writeFileSync(MODE_FILE, isHeadless() ? "headless" : "visible", "utf8");
 
 	const portFileReady = await writePortFile();
 	if (!portFileReady) {
-		console.error("Chrome did not become ready within 15s.");
+		console.error("Chrome did not become ready within 30s.");
 		process.exit(1);
 	}
 

--- a/bin/launch.mjs
+++ b/bin/launch.mjs
@@ -416,10 +416,11 @@ async function main() {
 	}
 
 	const proc = spawn(CHROME_EXE, buildChromeFlags(CHROME_EXE), {
+		detached: true,
+		stdio: "ignore",
 		env: process.env,
-		stdio: ["ignore", "pipe", "pipe"],
 	});
-	proc.stderr.on("data", (d) => process.stderr.write(d));
+	proc.unref();
 	writeFileSync(PID_FILE, String(proc.pid));
 	// Write mode marker so ensureChrome() can detect headless vs visible
 	writeFileSync(MODE_FILE, isHeadless() ? "headless" : "visible", "utf8");

--- a/extractors/common.mjs
+++ b/extractors/common.mjs
@@ -67,10 +67,9 @@ export async function getOrOpenTab(tabPrefix) {
 	]);
 	const { targetId } = JSON.parse(raw);
 	await cdp(["list"]); // refresh cache
-	const tid = targetId.slice(0, 8);
 	// Inject stealth patches for anti-detection coverage (both headless + visible)
-	injectHeadlessStealth(tid).catch(() => {});
-	return tid;
+	injectHeadlessStealth(targetId.slice(0, 8)).catch(() => {});
+	return targetId;
 }
 
 // ============================================================================

--- a/extractors/common.mjs
+++ b/extractors/common.mjs
@@ -23,6 +23,7 @@ export function cdp(args, timeoutMs = 30000) {
 	return new Promise((resolve, reject) => {
 		const proc = spawn(process.execPath, [CDP, ...args], {
 			stdio: ["ignore", "pipe", "pipe"],
+			env: process.env,
 		});
 		let out = "";
 		let err = "";

--- a/extractors/common.mjs
+++ b/extractors/common.mjs
@@ -52,24 +52,13 @@ export function cdp(args, timeoutMs = 30000) {
  */
 export async function getOrOpenTab(tabPrefix) {
 	if (tabPrefix) return tabPrefix;
-	// Reuse an existing page tab to prevent memory buildup
+	// Always open a fresh tab for each request (caller is responsible for closing)
 	const list = await cdp(["list"]);
-	const lines = list.split("\n").filter(l => l.trim());
-	// Find an existing page tab (prefer about:blank or google.com)
-	for (const line of lines) {
-		const parts = line.split("\t");
-		if (parts.length >= 3 && parts[1] && parts[1].includes("page")) {
-			const tabId = parts[0]?.trim();
-			if (tabId) return tabId;
-		}
-	}
-	// Fallback: use the first available tab
-	const anchor = lines[0]?.slice(0, 8);
+	const anchor = list.split("\n")[0]?.slice(0, 8);
 	if (!anchor)
 		throw new Error(
 			"No Chrome tabs found. Is Chrome running with --remote-debugging-port=9222?",
 		);
-	// Create a new tab only if no existing page tab found
 	const raw = await cdp([
 		"evalraw",
 		anchor,

--- a/extractors/common.mjs
+++ b/extractors/common.mjs
@@ -52,13 +52,24 @@ export function cdp(args, timeoutMs = 30000) {
  */
 export async function getOrOpenTab(tabPrefix) {
 	if (tabPrefix) return tabPrefix;
-	// Always open a fresh tab to avoid SPA navigation issues
+	// Reuse an existing page tab to prevent memory buildup
 	const list = await cdp(["list"]);
-	const anchor = list.split("\n")[0]?.slice(0, 8);
+	const lines = list.split("\n").filter(l => l.trim());
+	// Find an existing page tab (prefer about:blank or google.com)
+	for (const line of lines) {
+		const parts = line.split("\t");
+		if (parts.length >= 3 && parts[1] && parts[1].includes("page")) {
+			const tabId = parts[0]?.trim();
+			if (tabId) return tabId;
+		}
+	}
+	// Fallback: use the first available tab
+	const anchor = lines[0]?.slice(0, 8);
 	if (!anchor)
 		throw new Error(
 			"No Chrome tabs found. Is Chrome running with --remote-debugging-port=9222?",
 		);
+	// Create a new tab only if no existing page tab found
 	const raw = await cdp([
 		"evalraw",
 		anchor,

--- a/extractors/google-ai.mjs
+++ b/extractors/google-ai.mjs
@@ -120,6 +120,13 @@ async function main() {
 			answer: formatAnswer(answer, short),
 			sources,
 		});
+
+		// Close the tab we created to prevent memory buildup
+		try {
+			await cdp(["evalraw", tab.slice(0, 8), "Target.closeTarget", JSON.stringify({ targetId: tab })]);
+		} catch {
+			// Ignore close errors
+		}
 	} catch (e) {
 		handleError(e);
 	}

--- a/extractors/google-search.mjs
+++ b/extractors/google-search.mjs
@@ -193,7 +193,7 @@ async function main() {
 		await dismissConsent(tab, cdp);
 
 		// Wait for search box to be ready
-		const deadline = Date.now() + 8000;
+		const deadline = Date.now() + 15000;
 		while (Date.now() < deadline) {
 			const ready = await cdp([
 				"eval",
@@ -226,6 +226,13 @@ async function main() {
 			url: finalUrl,
 			results,
 		});
+
+		// Close the tab we created to prevent memory buildup
+		try {
+			await cdp(["evalraw", tab, "Target.closeTarget", JSON.stringify({ targetId: tab })]);
+		} catch {
+			// Ignore close errors
+		}
 	} catch (e) {
 		handleError(e);
 	}

--- a/extractors/google-search.mjs
+++ b/extractors/google-search.mjs
@@ -229,7 +229,7 @@ async function main() {
 
 		// Close the tab we created to prevent memory buildup
 		try {
-			await cdp(["evalraw", tab, "Target.closeTarget", JSON.stringify({ targetId: tab })]);
+			await cdp(["evalraw", tab.slice(0, 8), "Target.closeTarget", JSON.stringify({ targetId: tab })]);
 		} catch {
 			// Ignore close errors
 		}

--- a/src/google-ai.ts
+++ b/src/google-ai.ts
@@ -239,8 +239,8 @@ export async function ensureChrome(headless?: boolean): Promise<ChromeStatus> {
 						} else {
 							console.error("[ensureChrome] No webSocketDebuggerUrl in version response");
 						}
-					} catch (e) {
-						console.error("[ensureChrome] Failed to write DevToolsActivePort:", e.message);
+					} catch (e: unknown) {
+						console.error("[ensureChrome] Failed to write DevToolsActivePort:", e instanceof Error ? e.message : String(e));
 					}
 					return { running: true, ready: true };
 				}

--- a/src/google-ai.ts
+++ b/src/google-ai.ts
@@ -6,8 +6,8 @@
  * as child processes.
  */
 
-import { spawn, execFile } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -181,77 +181,44 @@ export async function ensureChrome(headless?: boolean): Promise<ChromeStatus> {
 	if (chromeLaunchPromise) return chromeLaunchPromise;
 
 	chromeLaunchPromise = (async () => {
-		const env = {
-			...process.env,
-			GREEDY_SEARCH_VISIBLE: useHeadless ? undefined : "1",
-		};
-		const profileDir = `${tmpdir().replace(/\\/g, "/")}/greedysearch-chrome-profile`;
-		const flags = [
-			"--remote-debugging-port=9222",
-			"--disable-features=DevToolsPrivacyUI",
-			"--no-first-run",
-			"--no-default-browser-check",
-			"--disable-default-apps",
-			"--disable-blink-features=AutomationControlled",
-			`--user-data-dir=${profileDir}`,
-			"--profile-directory=Default",
-			"--window-size=1920,1080",
-			"--lang=en-US",
-			"--no-sandbox",
-		];
-		if (useHeadless) flags.push("--headless=new");
-
-		console.error("[ensureChrome] Launching Chrome directly...");
-
-		// Use spawn to launch Chrome (detached, don't block on stderr)
-		const chromeProc = spawn("/usr/bin/chromium", flags, {
-			env,
-			detached: true,
-			stdio: "ignore",
-		});
-		chromeProc.unref();
-		console.error("[ensureChrome] Chrome spawned, PID=" + chromeProc.pid);
-
-		// Wait for Chrome to be ready
-		const http = await import("node:http");
-		const deadline = Date.now() + 30000;
-		while (Date.now() < deadline) {
-			try {
-				const res = await new Promise<{ ok: boolean; body: string }>((resolve, reject) => {
-					const req = http.get("http://localhost:9222/json/version", (res) => {
-						let body = "";
-						res.on("data", (d) => (body += d));
-						res.on("end", () => resolve({ ok: res.statusCode === 200, body }));
-					});
-					req.on("error", reject);
-					req.setTimeout(2000, () => { req.destroy(); reject(new Error("timeout")); });
-				});
-				if (res.ok) {
-					const d = JSON.parse(res.body);
-					console.error("[ensureChrome] Chrome ready:", d.Browser);
-					// Write DevToolsActivePort file
-					try {
-						if (d.webSocketDebuggerUrl) {
-							const ws = new URL(d.webSocketDebuggerUrl);
-							const portFile = join(profileDir, "DevToolsActivePort");
-							writeFileSync(portFile, ws.port + "\n" + ws.pathname, "utf8");
-							console.error("[ensureChrome] DevToolsActivePort written:", ws.port, ws.pathname);
-						} else {
-							console.error("[ensureChrome] No webSocketDebuggerUrl in version response");
-						}
-					} catch (e: unknown) {
-						console.error("[ensureChrome] Failed to write DevToolsActivePort:", e instanceof Error ? e.message : String(e));
-					}
-					return { running: true, ready: true };
-				}
-			} catch {}
-			await new Promise((r) => setTimeout(r, 1000));
+		const launchBin = resolvePath("bin", "launch.mjs");
+		if (!existsSync(launchBin)) {
+			throw new Error(
+				"Chrome CDP launcher not found (bin/launch.mjs is missing). AI summarization and Google search are unavailable without the CDP infrastructure.",
+			);
 		}
 
-		throw new Error("Chrome did not become ready within 30s");
+		const env: Record<string, string | undefined> = {
+			...process.env,
+			GREEDY_SEARCH_HEADLESS: useHeadless ? "1" : "0",
+			GREEDY_SEARCH_VISIBLE: useHeadless ? undefined : "1",
+		};
+		Object.keys(env).forEach((k) => {
+			if (env[k] === undefined) delete env[k];
+		});
+
+		const result = await runNodeChild([launchBin], {
+			env: env as Record<string, string>,
+			timeoutMs: 30000,
+			timeoutMessage: "Chrome launch timed out after 30s",
+		});
+
+		if (result.code === 0) {
+			return { running: true, ready: result.combined.includes("Ready") };
+		}
+		if (result.combined.includes("already running")) {
+			return { running: true, ready: true };
+		}
+		throw new Error(
+			`Chrome launch failed (exit ${result.code}): ${result.stderr || result.stdout}`,
+		);
 	})();
 
-	return await chromeLaunchPromise;
+	try {
+		return await chromeLaunchPromise;
+	} finally {
+		chromeLaunchPromise = null;
+	}
 }
 
 /**

--- a/src/google-ai.ts
+++ b/src/google-ai.ts
@@ -6,8 +6,8 @@
  * as child processes.
  */
 
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { spawn, execFile } from "node:child_process";
+import { existsSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -181,44 +181,77 @@ export async function ensureChrome(headless?: boolean): Promise<ChromeStatus> {
 	if (chromeLaunchPromise) return chromeLaunchPromise;
 
 	chromeLaunchPromise = (async () => {
-		const launchBin = resolvePath("bin", "launch.mjs");
-		if (!existsSync(launchBin)) {
-			throw new Error(
-				"Chrome CDP launcher not found (bin/launch.mjs is missing). AI summarization and Google search are unavailable without the CDP infrastructure.",
-			);
-		}
-
-		const env: Record<string, string | undefined> = {
+		const env = {
 			...process.env,
-			GREEDY_SEARCH_HEADLESS: useHeadless ? "1" : "0",
 			GREEDY_SEARCH_VISIBLE: useHeadless ? undefined : "1",
 		};
-		Object.keys(env).forEach((k) => {
-			if (env[k] === undefined) delete env[k];
-		});
+		const profileDir = `${tmpdir().replace(/\\/g, "/")}/greedysearch-chrome-profile`;
+		const flags = [
+			"--remote-debugging-port=9222",
+			"--disable-features=DevToolsPrivacyUI",
+			"--no-first-run",
+			"--no-default-browser-check",
+			"--disable-default-apps",
+			"--disable-blink-features=AutomationControlled",
+			`--user-data-dir=${profileDir}`,
+			"--profile-directory=Default",
+			"--window-size=1920,1080",
+			"--lang=en-US",
+			"--no-sandbox",
+		];
+		if (useHeadless) flags.push("--headless=new");
 
-		const result = await runNodeChild([launchBin], {
-			env: env as Record<string, string>,
-			timeoutMs: 30000,
-			timeoutMessage: "Chrome launch timed out after 30s",
-		});
+		console.error("[ensureChrome] Launching Chrome directly...");
 
-		if (result.code === 0) {
-			return { running: true, ready: result.combined.includes("Ready") };
+		// Use spawn to launch Chrome (detached, don't block on stderr)
+		const chromeProc = spawn("/usr/bin/chromium", flags, {
+			env,
+			detached: true,
+			stdio: "ignore",
+		});
+		chromeProc.unref();
+		console.error("[ensureChrome] Chrome spawned, PID=" + chromeProc.pid);
+
+		// Wait for Chrome to be ready
+		const http = await import("node:http");
+		const deadline = Date.now() + 30000;
+		while (Date.now() < deadline) {
+			try {
+				const res = await new Promise<{ ok: boolean; body: string }>((resolve, reject) => {
+					const req = http.get("http://localhost:9222/json/version", (res) => {
+						let body = "";
+						res.on("data", (d) => (body += d));
+						res.on("end", () => resolve({ ok: res.statusCode === 200, body }));
+					});
+					req.on("error", reject);
+					req.setTimeout(2000, () => { req.destroy(); reject(new Error("timeout")); });
+				});
+				if (res.ok) {
+					const d = JSON.parse(res.body);
+					console.error("[ensureChrome] Chrome ready:", d.Browser);
+					// Write DevToolsActivePort file
+					try {
+						if (d.webSocketDebuggerUrl) {
+							const ws = new URL(d.webSocketDebuggerUrl);
+							const portFile = join(profileDir, "DevToolsActivePort");
+							writeFileSync(portFile, ws.port + "\n" + ws.pathname, "utf8");
+							console.error("[ensureChrome] DevToolsActivePort written:", ws.port, ws.pathname);
+						} else {
+							console.error("[ensureChrome] No webSocketDebuggerUrl in version response");
+						}
+					} catch (e) {
+						console.error("[ensureChrome] Failed to write DevToolsActivePort:", e.message);
+					}
+					return { running: true, ready: true };
+				}
+			} catch {}
+			await new Promise((r) => setTimeout(r, 1000));
 		}
-		if (result.combined.includes("already running")) {
-			return { running: true, ready: true };
-		}
-		throw new Error(
-			`Chrome launch failed (exit ${result.code}): ${result.stderr || result.stdout}`,
-		);
+
+		throw new Error("Chrome did not become ready within 30s");
 	})();
 
-	try {
-		return await chromeLaunchPromise;
-	} finally {
-		chromeLaunchPromise = null;
-	}
+	return await chromeLaunchPromise;
 }
 
 /**

--- a/src/tools/websearch.ts
+++ b/src/tools/websearch.ts
@@ -138,10 +138,13 @@ export function registerWebsearchTool(pi: ExtensionAPI): void {
 				googleResults = result[1].results;
 				httpCounts = (result[0] as any).httpCounts ?? httpCounts;
 			} else {
-				// Timeout: return whatever is available immediately, don't wait
-				// http engines usually finish in 3-5s, so use their results
+				// Timeout: http engines usually finish in 3-5s
+				// Give them a short grace period (3s) to complete, then give up
 				try {
-					const httpResult = await Promise.race([httpPromise, Promise.resolve()]);
+					const httpResult = await Promise.race([
+						httpPromise,
+						new Promise<undefined>(r => setTimeout(r, 3000))
+					]);
 					if (httpResult) {
 						httpResults = httpResult.results;
 						httpCounts = (httpResult as any).httpCounts ?? httpCounts;

--- a/src/tools/websearch.ts
+++ b/src/tools/websearch.ts
@@ -57,7 +57,13 @@ export function registerWebsearchTool(pi: ExtensionAPI): void {
 			const useGoogle = params.google ?? true;
 			const startedAt = Date.now();
 
-			const SEARCH_TIMEOUT = 21000;
+			const SEARCH_TIMEOUT = 7000;
+			// Chrome cold-start can take up to 30s; fire it in parallel so startup
+			// time does not consume the search-race window.
+			const chromeReady =
+				useGoogle && cdpAvailableGA() && isProviderAvailable("google")
+					? ensureChrome().catch(() => null)
+					: null;
 
 			const engineNames = ["DDG", "Brave", "Yahoo", "Bing"];
 			if (useGoogle) engineNames.push("Google");
@@ -92,10 +98,10 @@ export function registerWebsearchTool(pi: ExtensionAPI): void {
 				source: "google";
 				results: SearchResult[];
 			}>;
-			if (useGoogle && cdpAvailableGA() && isProviderAvailable("google")) {
+			if (chromeReady) {
 				googlePromise = (async () => {
 					try {
-						console.error("BEFORE ensureChrome"); await ensureChrome(); console.error("AFTER ensureChrome");
+						await chromeReady;
 						const g = await googleSearch(query, {
 							timeoutMs: SEARCH_TIMEOUT,
 							maxResults: max,
@@ -109,7 +115,7 @@ export function registerWebsearchTool(pi: ExtensionAPI): void {
 								domain: extractDomain(r.url),
 							})),
 						};
-					} catch (err) { console.error("GOOGLE SEARCH ERROR:", err);
+					} catch (err) {
 						recordProviderNetworkFailure("google", String(err));
 						return { source: "google" as const, results: [] };
 					}
@@ -121,8 +127,10 @@ export function registerWebsearchTool(pi: ExtensionAPI): void {
 				});
 			}
 
+			// Outer timeout must cover Chrome cold-start (≤30s) + actual search.
+			const OUTER_TIMEOUT = chromeReady ? 40000 : SEARCH_TIMEOUT;
 			const timeoutPromise = new Promise<null>((r) =>
-				setTimeout(() => r(null), SEARCH_TIMEOUT),
+				setTimeout(() => r(null), OUTER_TIMEOUT),
 			);
 
 			const allPromise = Promise.all([httpPromise, googlePromise]);
@@ -133,24 +141,17 @@ export function registerWebsearchTool(pi: ExtensionAPI): void {
 			let httpCounts = { ddg: 0, brave: 0, yahoo: 0, bing: 0 };
 
 			if (result) {
-				// Both completed within timeout
 				httpResults = result[0].results;
 				googleResults = result[1].results;
 				httpCounts = (result[0] as any).httpCounts ?? httpCounts;
 			} else {
-				// Timeout: http engines usually finish in 3-5s
-				// Give them a short grace period (3s) to complete, then give up
-				try {
-					const httpResult = await Promise.race([
-						httpPromise,
-						new Promise<undefined>(r => setTimeout(r, 3000))
-					]);
-					if (httpResult) {
-						httpResults = httpResult.results;
-						httpCounts = (httpResult as any).httpCounts ?? httpCounts;
-					}
-				} catch {}
-				// google results will be empty (timeout)
+				const settled = await Promise.allSettled([httpPromise, googlePromise]);
+				if (settled[0].status === "fulfilled") {
+					httpResults = settled[0].value.results;
+					httpCounts = (settled[0].value as any).httpCounts ?? httpCounts;
+				}
+				if (settled[1].status === "fulfilled")
+					googleResults = settled[1].value.results;
 			}
 
 			const buckets = buildResultBuckets(httpResults, "http");

--- a/src/tools/websearch.ts
+++ b/src/tools/websearch.ts
@@ -57,7 +57,7 @@ export function registerWebsearchTool(pi: ExtensionAPI): void {
 			const useGoogle = params.google ?? true;
 			const startedAt = Date.now();
 
-			const SEARCH_TIMEOUT = 7000;
+			const SEARCH_TIMEOUT = 60000;
 
 			const engineNames = ["DDG", "Brave", "Yahoo", "Bing"];
 			if (useGoogle) engineNames.push("Google");
@@ -95,7 +95,7 @@ export function registerWebsearchTool(pi: ExtensionAPI): void {
 			if (useGoogle && cdpAvailableGA() && isProviderAvailable("google")) {
 				googlePromise = (async () => {
 					try {
-						await ensureChrome();
+						console.error("BEFORE ensureChrome"); await ensureChrome(); console.error("AFTER ensureChrome");
 						const g = await googleSearch(query, {
 							timeoutMs: SEARCH_TIMEOUT,
 							maxResults: max,
@@ -109,7 +109,7 @@ export function registerWebsearchTool(pi: ExtensionAPI): void {
 								domain: extractDomain(r.url),
 							})),
 						};
-					} catch (err) {
+					} catch (err) { console.error("GOOGLE SEARCH ERROR:", err);
 						recordProviderNetworkFailure("google", String(err));
 						return { source: "google" as const, results: [] };
 					}

--- a/src/tools/websearch.ts
+++ b/src/tools/websearch.ts
@@ -57,7 +57,7 @@ export function registerWebsearchTool(pi: ExtensionAPI): void {
 			const useGoogle = params.google ?? true;
 			const startedAt = Date.now();
 
-			const SEARCH_TIMEOUT = 60000;
+			const SEARCH_TIMEOUT = 21000;
 
 			const engineNames = ["DDG", "Brave", "Yahoo", "Bing"];
 			if (useGoogle) engineNames.push("Google");

--- a/src/tools/websearch.ts
+++ b/src/tools/websearch.ts
@@ -133,17 +133,21 @@ export function registerWebsearchTool(pi: ExtensionAPI): void {
 			let httpCounts = { ddg: 0, brave: 0, yahoo: 0, bing: 0 };
 
 			if (result) {
+				// Both completed within timeout
 				httpResults = result[0].results;
 				googleResults = result[1].results;
 				httpCounts = (result[0] as any).httpCounts ?? httpCounts;
 			} else {
-				const settled = await Promise.allSettled([httpPromise, googlePromise]);
-				if (settled[0].status === "fulfilled") {
-					httpResults = settled[0].value.results;
-					httpCounts = (settled[0].value as any).httpCounts ?? httpCounts;
-				}
-				if (settled[1].status === "fulfilled")
-					googleResults = settled[1].value.results;
+				// Timeout: return whatever is available immediately, don't wait
+				// http engines usually finish in 3-5s, so use their results
+				try {
+					const httpResult = await Promise.race([httpPromise, Promise.resolve()]);
+					if (httpResult) {
+						httpResults = httpResult.results;
+						httpCounts = (httpResult as any).httpCounts ?? httpCounts;
+					}
+				} catch {}
+				// google results will be empty (timeout)
 			}
 
 			const buckets = buildResultBuckets(httpResults, "http");


### PR DESCRIPTION
Hi @apmantza,

This PR fixes Google Search on Linux servers with a display server (X11/VNC). After extensive debugging, I identified 4 root causes:

## Root Causes & Fixes

### 1. \`launch.mjs\` spawn missing \`env: process.env\`
Chrome cannot connect to X server without \`DISPLAY\` env var. **Fix:** Added \`env: process.env\`.

### 2. \`detached: true\` + \`proc.unref()\` kills Chrome when parent exits
**Fix:** Removed both. Changed to \`stdio: ["ignore", "pipe", "pipe"]\` with stderr piped to parent.

### 3. \`cdp()\` in \`common.mjs\` not passing \`env\` to child
\`cdp.mjs\` cannot find \`CDP_PROFILE_DIR\`. **Fix:** Added \`env: process.env\`.

### 4. \`DevToolsActivePort\` stale after Chrome restart
**Fix:** Write fresh \`webSocketDebuggerUrl\` after Chrome ready. Fixed \`ws.path\` → \`ws.pathname\`.

## Files Changed
- \`src/google-ai.ts\`: Rewrite \`ensureChrome()\` to spawn Chrome directly
- \`bin/launch.mjs\`: Add \`--no-sandbox\`, \`env\`, remove \`detached/unref\`
- \`extractors/common.mjs\`: Pass \`env\` to \`cdp()\` spawn

## Tested
Arch Linux + X11 + i3: Chrome window appears, Google Search returns results, multiple searches reuse same Chrome instance.