### PR TITLE
Unref session-cache cleanup interval so `pi -p` can exit

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,8 +18,12 @@ export default function (pi: ExtensionAPI) {
 	// Load persisted content cache from disk (lazy — contents loaded on first access)
 	loadContentCacheFromDisk();
 
-	// Start session cache cleanup
-	setInterval(cleanupSessionCache, SESSION_CACHE_CLEANUP_MS);
+	// Start session cache cleanup.
+	// .unref() so this recurring timer does not keep the Node.js event loop
+	// alive on its own. Without it, one-shot `pi -p` invocations never exit:
+	// the agent finishes and prints its answer, but the process hangs until
+	// killed because the ref'd interval keeps the loop running.
+	setInterval(cleanupSessionCache, SESSION_CACHE_CLEANUP_MS).unref();
 
 	// Register all 6 tools
 	registerWebfetchTool(pi);


### PR DESCRIPTION
## Problem

The recurring `setInterval(cleanupSessionCache, SESSION_CACHE_CLEANUP_MS)` in the extension entrypoint (`index.ts`) is never `.unref()`'d, so it keeps the Node.js event loop alive on its own.

In long-running interactive `pi` sessions this is harmless. But in one-shot **`pi -p`** (non-interactive) mode it means the process **never exits**: the agent finishes and prints its answer, then the process hangs until something external kills it.

### How it shows up

When orchestrating non-interactive `pi -p` workers with pi-webaio loaded, *every* call appears to "hang" regardless of provider/model. The output is actually produced quickly — the process just won't terminate. Bisecting loaded extensions points at pi-webaio; the held handle is this interval.

Minimal repro:
```bash
pi -p "say hi"        # prints the answer, then hangs until Ctrl-C / timeout
pi -p -ne "say hi"    # exits cleanly (extensions disabled)
```

## Fix

`.unref()` the interval. The cleanup timer still fires while the process has other work pending, but no longer keeps the process alive by itself, so `pi -p` exits cleanly once the agent is done.

```diff
-	setInterval(cleanupSessionCache, SESSION_CACHE_CLEANUP_MS);
+	setInterval(cleanupSessionCache, SESSION_CACHE_CLEANUP_MS).unref();
```

## Verification

With the fix applied locally, a full default extension set (including pi-webaio) running `pi -p "say hi"` exits cleanly (~9s, exit 0) instead of hanging. Networked research tasks (`pi -p --sandbox-network …`) also complete and exit cleanly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)