### PR TITLE
feat(webfetch): query-focused answer mode

### DIFF
--- a/src/tools/webfetch.ts
+++ b/src/tools/webfetch.ts
@@ -21,6 +21,7 @@ import {
 	formatInteractablesSection,
 } from "../interactive-elements.ts";
 import { pruneMarkdown } from "../prune-markdown.ts";
+import { createBM25Scorer } from "../bm25.ts";
 import {
 	BASE_TEMP,
 	getSearchContext,
@@ -215,6 +216,87 @@ export function maybeChunkMarkdown(
 	}
 }
 
+/** Default number of top chunks returned in answer mode. */
+export const DEFAULT_TOP_CHUNKS = 5;
+
+/**
+ * Apply query-focused answer mode to a markdown body.
+ *
+ * Chunks the markdown, scores each chunk by BM25 against the query,
+ * selects the top-k highest-scoring chunks (breaking ties by document
+ * position), re-orders them by original position, and prefixes each
+ * with its heading breadcrumb. A footer notes how many sections were
+ * omitted and that the full content is cached.
+ *
+ * Returns `undefined` when the body is empty, the query is empty, or
+ * chunking yields no results so the caller can fall back to full content.
+ *
+ * @internal Exported for unit tests only.
+ */
+export function applyQueryAnswerMode(
+	body: string,
+	query: string,
+	topK: number = DEFAULT_TOP_CHUNKS,
+	chunkOptions: { maxTokens?: number; overlapTokens?: number } = {},
+): string | undefined {
+	if (!body || !query?.trim()) return undefined;
+
+	let chunks: Chunk[];
+	try {
+		chunks = chunkMarkdown(body, chunkOptions);
+	} catch {
+		return undefined;
+	}
+	if (chunks.length === 0) return undefined;
+
+	// Score all chunks in one pass (better IDF than scoring one at a time).
+	const scorer = createBM25Scorer(query);
+	const texts = chunks.map((c) => c.text);
+	const scores = scorer.scoreAll(texts);
+
+	// Pair each chunk with its score and original index.
+	const scored = chunks.map((c, i) => ({ chunk: c, score: scores[i] ?? 0 }));
+
+	// Select top-k by score; preserve document order among ties.
+	const sorted = scored.slice().sort((a, b) => b.score - a.score);
+	const topK_ = Math.max(1, Math.floor(topK));
+	const selected = sorted.slice(0, topK_);
+
+	// Re-sort selected chunks by original document position.
+	selected.sort((a, b) => a.chunk.index - b.chunk.index);
+
+	const omitted = chunks.length - selected.length;
+
+	// Build a heading-breadcrumb for each chunk by scanning ALL chunks in
+	// document order (not just the selected ones) to track heading context.
+	// This correctly handles the case where the chunker splits a heading
+	// into a separate chunk from its body text, and also handles overlap
+	// prepending (which means chunk.text may not be verbatim in `body`).
+	const HEADING_INLINE_RE = /^#{1,6}\s+(.+)/m;
+
+	// Walk all chunks in order, tracking the last heading seen.
+	const headingByIndex = new Map<number, string>();
+	let currentHeadingCtx = "";
+	for (const c of chunks) {
+		const hm = c.text.match(HEADING_INLINE_RE);
+		if (hm) currentHeadingCtx = hm[1]!.trim();
+		headingByIndex.set(c.index, currentHeadingCtx);
+	}
+
+	const parts = selected.map(({ chunk }) => {
+		const heading = headingByIndex.get(chunk.index) ?? "";
+		const breadcrumb = heading ? `> **${heading}**\n\n` : "";
+		return `${breadcrumb}${chunk.text}`;
+	});
+
+	const footer =
+		omitted > 0
+			? `\n\n---\n_${omitted} section${omitted === 1 ? "" : "s"} omitted. Full content cached — retrieve with aio-webcontent by URL._`
+			: `\n\n---\n_Full content cached — retrieve with aio-webcontent by URL._`;
+
+	return parts.join("\n\n---\n\n") + footer;
+}
+
 export function registerWebfetchTool(pi: ExtensionAPI): void {
 	pi.registerTool({
 		name: "aio-webfetch",
@@ -222,7 +304,7 @@ export function registerWebfetchTool(pi: ExtensionAPI): void {
 		description:
 			"Fetch a single URL (or batch of URLs) and convert to markdown with anti-bot TLS fingerprinting. Detects PDFs, GitHub repos, and Next.js RSC. Long content is automatically summarized via Gemini AI; full content always saved to file.",
 		promptSnippet:
-			"aio-webfetch(url|urls, mode?, browser?, os?, proxy?, prune?, query?, interactive?, bypass?, bypassStrategies?, compile?, out?, cacheTtlSeconds?, start_index?, max_length?, format?): fetch URL(s) with anti-bot TLS fingerprinting, defuddle extraction, and optional AI summary. Default `format=markdown` saves to disk; pass `format=html|text|json|raw` for an in-memory body. Use the read tool on the saved path for full text.",
+			"aio-webfetch(url|urls, mode?, browser?, os?, proxy?, prune?, query?, topChunks?, interactive?, bypass?, bypassStrategies?, compile?, out?, cacheTtlSeconds?, start_index?, max_length?, format?): fetch URL(s) with anti-bot TLS fingerprinting, defuddle extraction, and optional AI summary. Default `format=markdown` saves to disk; pass `format=html|text|json|raw` for an in-memory body. Use the read tool on the saved path for full text. Pass `query` alone for answer mode: returns top-k BM25-scored chunks with heading breadcrumbs; full content cached for aio-webcontent.",
 		promptGuidelines: [
 			"Use aio-webfetch when the user wants to retrieve specific webpage(s), article(s), or file(s).",
 			"Use aio-webpull when the user wants to download an entire site or docs collection.",
@@ -286,7 +368,14 @@ export function registerWebfetchTool(pi: ExtensionAPI): void {
 			query: Type.Optional(
 				Type.String({
 					description:
-						"Optional relevance query used with prune. When set, pruning keeps sections most relevant to this query using BM25 scoring.",
+						"Relevance query for answer mode or query-aware pruning. When set without `prune`, activates answer mode: the page is chunked and only the top-k most relevant chunks (scored by BM25) are returned — ordered by document position with heading breadcrumbs. The full content is still cached so aio-webcontent can retrieve it by URL. When used with `prune`, keeps sections most relevant to this query during pruning.",
+				}),
+			),
+			topChunks: Type.Optional(
+				Type.Number({
+					description:
+						"Maximum number of top-scoring chunks to return in answer mode (query set, prune absent). Default 5. Min 1.",
+					minimum: 1,
 				}),
 			),
 			interactive: Type.Optional(
@@ -947,6 +1036,80 @@ export function registerWebfetchTool(pi: ExtensionAPI): void {
 					const responseId = (r as any).responseId as string | undefined;
 					let summaryNotice: string;
 					let displayContent: string;
+
+					// ── Answer mode ──────────────────────────────────────────────
+					// When `query` is set without `prune`, return only the top-k
+					// most relevant chunks scored by BM25. Full content is already
+					// stored above; only the agent-visible display is narrowed.
+					const answerModeQuery = params.query as string | undefined;
+					const answerModePrune = params.prune as number | undefined;
+					const answerModeActive =
+						!!answerModeQuery && !answerModePrune && itemFormat === "markdown";
+					if (answerModeActive) {
+						const topK = (params.topChunks as number | undefined) ?? DEFAULT_TOP_CHUNKS;
+						const answerBody = applyQueryAnswerMode(
+							(r as any).body ?? preview,
+							answerModeQuery!,
+							topK,
+							{
+								maxTokens: params.maxTokens as number | undefined,
+								overlapTokens: params.overlapTokens as number | undefined,
+							},
+						);
+						if (answerBody !== undefined) {
+							summaryNotice = r.outPath
+								? `\n[Answer mode: top ${topK} chunks for "${answerModeQuery}". Full content (${preview.length} chars) saved to ${r.outPath}.]`
+								: `\n[Answer mode: top ${topK} chunks for "${answerModeQuery}". Full content cached (result ID ${responseId ?? "unavailable"}).]`;
+							displayContent = answerBody;
+							// Skip the normal summarize/truncate path.
+							const formatLabel =
+								`✓ Fetched and saved to ${r.outPath}${summaryNotice}`;
+							const chunks =
+								maybeChunkMarkdown((r as any).body, params, chunkingErrors);
+							const chunkFmt = formatChunksText(
+								chunks,
+								params.overlapTokens ?? DEFAULT_OVERLAP_TOKENS,
+							);
+							const text = [
+								formatLabel,
+								`\nTitle: ${r.title}`,
+								`URL: ${r.url}`,
+								`Format: ${itemFormat}`,
+								`Response ID: ${responseId}`,
+								chunkFmt.header ? `\n${chunkFmt.header}` : "",
+								"\n---\n",
+								displayContent,
+								chunkFmt.body
+									? ["\n\n---\n", `## Chunks (${chunks!.length})\n`, chunkFmt.body].join("\n")
+									: "",
+								chunkingErrors.length > 0
+									? `\n\n[WARN] Chunking failed: ${chunkingErrors.join("; ")}`
+									: "",
+							].join("\n");
+							return {
+								content: [{ type: "text", text }],
+								details: {
+									outPath: r.outPath,
+									title: r.title,
+									url: r.url,
+									responseId,
+									browser,
+									os,
+									proxy,
+									truncated: false,
+									summarized: false,
+									fullLength: preview.length,
+									status: "done",
+									progress: 1,
+									spinnerTick: details.spinnerTick,
+									content: displayContent,
+									format: itemFormat,
+									chunks,
+									items: details.items,
+								},
+							};
+						}
+					}
 
 					const compactJsonPreview = !summarized
 						? buildCompactJsonPreview(preview, {

--- a/tests/query-mode.test.mjs
+++ b/tests/query-mode.test.mjs
@@ -1,0 +1,228 @@
+// ─── Tests for query-focused answer mode ────────────────────────────
+//
+// Covers applyQueryAnswerMode():
+//   - Returns top-k chunks relevant to query
+//   - Chunks are ordered by document position (not score)
+//   - Heading breadcrumbs are prepended to each selected chunk
+//   - Footer notes omitted sections and mentions aio-webcontent
+//   - Returns undefined for empty body or empty query
+//   - No-op path: when query is absent, full content is unaffected
+//     (tested via the raw helper; execute() is integration-only)
+//
+// NOTE: Chunking is token-bounded (default 512 tokens). Small sections
+// merge into fewer chunks. Tests that need multi-chunk behavior use a
+// small maxTokens (e.g. 20) so each paragraph becomes its own chunk.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+	applyQueryAnswerMode,
+	DEFAULT_TOP_CHUNKS,
+} from "../src/tools/webfetch.ts";
+
+// ─── Helper ──────────────────────────────────────────────────────────
+
+/**
+ * Build a simple multi-section markdown doc.
+ * Each section has enough words to form a discrete chunk at maxTokens=20.
+ */
+function makeDoc(sections) {
+	return sections
+		.map(({ heading, body }) => `## ${heading}\n\n${body}`)
+		.join("\n\n");
+}
+
+// ─── Edge cases ───────────────────────────────────────────────────────
+
+test("applyQueryAnswerMode: returns undefined for empty body", () => {
+	assert.equal(applyQueryAnswerMode("", "pricing"), undefined);
+	assert.equal(applyQueryAnswerMode("   ", "pricing"), undefined);
+});
+
+test("applyQueryAnswerMode: returns undefined for empty query", () => {
+	const body = makeDoc([{ heading: "Intro", body: "Some content here." }]);
+	assert.equal(applyQueryAnswerMode(body, ""), undefined);
+	assert.equal(applyQueryAnswerMode(body, "   "), undefined);
+});
+
+test("applyQueryAnswerMode: returns undefined for null/undefined query", () => {
+	const body = makeDoc([{ heading: "Intro", body: "Some content here." }]);
+	assert.equal(applyQueryAnswerMode(body, undefined), undefined);
+	assert.equal(applyQueryAnswerMode(body, null), undefined);
+});
+
+// ─── Relevance selection ──────────────────────────────────────────────
+
+test("applyQueryAnswerMode: selects chunks relevant to query (small maxTokens)", () => {
+	// Use maxTokens=20 so each section becomes its own chunk.
+	// With topK=1, only the most relevant chunk should appear.
+	const doc = makeDoc([
+		{
+			heading: "Introduction",
+			body: "This page describes the product overview and general information about the platform.",
+		},
+		{
+			heading: "Pricing Plans",
+			body: "Our pricing plans include Free Pro and Enterprise tiers. Monthly billing is available for all plans.",
+		},
+		{
+			heading: "Installation Guide",
+			body: "Download the installer from our website and follow the setup wizard to complete installation.",
+		},
+		{
+			heading: "Support",
+			body: "Contact support via email or chat for help with any issues you encounter.",
+		},
+	]);
+
+	const result = applyQueryAnswerMode(doc, "pricing billing plans", 1, {
+		maxTokens: 20,
+	});
+	assert.ok(result !== undefined, "should return a result");
+	// Top chunk for "pricing billing plans" should contain pricing content
+	assert.ok(
+		result.includes("Pricing Plans") ||
+			result.includes("pricing") ||
+			result.includes("billing"),
+		"result should contain pricing or billing content",
+	);
+});
+
+// ─── Document order ───────────────────────────────────────────────────
+
+test("applyQueryAnswerMode: selected chunks are in document order", () => {
+	// Two sections about authentication — both should appear in document order.
+	// Use maxTokens=20 so they become separate chunks.
+	const doc = [
+		"## Section Alpha\n\nAuthentication token required for all API calls to the service endpoint.",
+		"## Section Beta\n\nGeneral information about the platform features and capabilities.",
+		"## Section Gamma\n\nToken refresh: obtain a new authentication token when the current one expires.",
+	].join("\n\n");
+
+	const result = applyQueryAnswerMode(doc, "authentication token", 2, {
+		maxTokens: 20,
+	});
+	assert.ok(result !== undefined, "should return a result");
+
+	const posAlpha = result.indexOf("Section Alpha");
+	const posGamma = result.indexOf("Section Gamma");
+
+	// Both auth sections should appear, and Alpha before Gamma
+	if (posAlpha !== -1 && posGamma !== -1) {
+		assert.ok(posAlpha < posGamma, "Alpha must appear before Gamma (document order)");
+	}
+	// At least one auth section should be in the result
+	assert.ok(
+		result.includes("authentication") || result.includes("token"),
+		"should include authentication-related content",
+	);
+});
+
+// ─── Heading breadcrumbs ──────────────────────────────────────────────
+
+test("applyQueryAnswerMode: heading breadcrumbs are present", () => {
+	const doc = makeDoc([
+		{
+			heading: "Getting Started",
+			body: "Install the package with the package manager command and follow the instructions to complete setup.",
+		},
+		{
+			heading: "Configuration",
+			body: "Configure the package by editing the configuration file with your specific application settings.",
+		},
+		{
+			heading: "API Reference",
+			body: "Full API documentation covering all methods and parameters available to developers.",
+		},
+	]);
+
+	// Ask for top 1 chunk; whichever is selected should have a breadcrumb.
+	const result = applyQueryAnswerMode(doc, "configuration settings", 1, {
+		maxTokens: 20,
+	});
+	assert.ok(result !== undefined, "should return a result");
+	// The breadcrumb format is "> **<heading>**"
+	assert.ok(
+		result.includes("> **"),
+		"result should contain breadcrumb markers",
+	);
+});
+
+// ─── Footer ───────────────────────────────────────────────────────────
+
+test("applyQueryAnswerMode: footer mentions omitted sections count (small maxTokens)", () => {
+	// With maxTokens=20 and 5 sections, we get ~5 chunks; topK=1 → 4 omitted.
+	const doc = makeDoc([
+		{
+			heading: "Alpha",
+			body: "Alpha section about authentication tokens and access management for users.",
+		},
+		{
+			heading: "Beta",
+			body: "Beta section about pricing and billing costs for subscription management.",
+		},
+		{
+			heading: "Gamma",
+			body: "Gamma section about deployment and hosting configuration on the servers.",
+		},
+		{
+			heading: "Delta",
+			body: "Delta section about monitoring and alert configuration for the application.",
+		},
+		{
+			heading: "Epsilon",
+			body: "Epsilon section about analytics and reporting features for dashboard users.",
+		},
+	]);
+
+	// Request 1 chunk from 5 sections → 4 omitted
+	const result = applyQueryAnswerMode(doc, "authentication token api", 1, {
+		maxTokens: 20,
+	});
+	assert.ok(result !== undefined, "should return a result");
+	assert.ok(result.includes("omitted"), "footer should mention omitted sections");
+	assert.ok(
+		result.includes("aio-webcontent"),
+		"footer should mention aio-webcontent for full content retrieval",
+	);
+});
+
+test("applyQueryAnswerMode: footer mentions aio-webcontent even with no omissions", () => {
+	// Single-chunk doc → 0 omitted, but footer still shows aio-webcontent link.
+	const doc = "## Only Section\n\nThis is the only section with content.";
+	const result = applyQueryAnswerMode(doc, "section content", 10);
+	assert.ok(result !== undefined, "should return a result");
+	assert.ok(
+		result.includes("aio-webcontent"),
+		"footer should always mention aio-webcontent",
+	);
+});
+
+// ─── topK parameter ───────────────────────────────────────────────────
+
+test("applyQueryAnswerMode: respects topK=1 (only one chunk returned)", () => {
+	// 5 sections at maxTokens=20 → 5 chunks; topK=1 → only 1 returned.
+	const sections = Array.from({ length: 5 }, (_, i) => ({
+		heading: `Section ${i + 1}`,
+		body: `Content for section ${i + 1} with query terms alpha beta gamma delta epsilon zeta eta theta.`,
+	}));
+	const doc = makeDoc(sections);
+
+	const result = applyQueryAnswerMode(doc, "alpha beta gamma", 1, {
+		maxTokens: 20,
+	});
+	assert.ok(result !== undefined);
+	// With topK=1, only 1 chunk; separators: 0 inter-chunk + 1 footer = 1 total.
+	// Count "---" occurrences (footer separator).
+	const separatorCount = (result.match(/\n---\n/g) ?? []).length;
+	assert.ok(
+		separatorCount >= 1,
+		`expected at least 1 separator (footer), got ${separatorCount}`,
+	);
+	// The omitted count should reflect 4 omitted sections
+	assert.ok(result.includes("omitted"), "footer should say something was omitted");
+});
+
+test("applyQueryAnswerMode: DEFAULT_TOP_CHUNKS is 5", () => {
+	assert.equal(DEFAULT_TOP_CHUNKS, 5);
+});


### PR DESCRIPTION
Closes #42.

Adds an optional `query` parameter to `aio-webfetch`. When set, the tool chunks the extracted markdown, scores chunks with BM25 against the query, and returns only the top-k chunks (default 5, configurable via `topChunks`) in document order, each prefixed with its heading breadcrumb. A footer notes how many sections were omitted and that the full page remains cached for `aio-webcontent` retrieval.

- Full content is still stored via `storeContent`/`storeResult` before the display is narrowed
- Existing query-aware `prune` path takes precedence; no behavior change when `query` is absent
- 10 new tests in `tests/query-mode.test.mjs`; full suite and tsc pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)