### PR TITLE
feat: hard token budget (budgetTokens) on webfetch and webcontent

### DIFF
--- a/src/prune-markdown.ts
+++ b/src/prune-markdown.ts
@@ -22,7 +22,7 @@ const MIN_SECTION_CHARS = 80;
  * Split markdown into logical sections.
  * A section starts with a heading (# .. ## .. ###) or a horizontal rule (---).
  */
-function splitSections(markdown: string): Array<{
+export function splitSections(markdown: string): Array<{
 	heading: string;
 	level: number;
 	content: string;
@@ -380,6 +380,100 @@ export function pruneByRelevance(
 	return pruneMarkdown(markdown, { maxTokens, query }) as ReturnType<
 		typeof pruneByRelevance
 	>;
+}
+
+/**
+ * Apply a hard token-budget contract to already-processed content.
+ *
+ * Unlike `pruneMarkdown` (which operates on raw source), this function is
+ * designed to be applied *after* answer-mode or other transformations have
+ * already narrowed the content.  It:
+ *
+ * 1. Returns the content unchanged when it already fits.
+ * 2. Extracts a heading skeleton (all heading lines) to always preserve structure.
+ * 3. Drops lowest-value sections first:
+ *    - With a `query`: lowest-BM25-scored sections go first.
+ *    - Without a `query`: sections are dropped from the bottom up.
+ * 4. Appends a standardised footer noting how many sections were omitted
+ *    and that the full content is cached.
+ * 5. Re-measures after pruning and hard-trims if still over budget (footer
+ *    counts against the budget).
+ *
+ * @param content   Text to fit within the budget.
+ * @param budget    Hard token limit (minimum 100).
+ * @param query     Optional relevance query — drives BM25 section ordering.
+ * @param url       URL used in the footer so the agent knows where to retrieve
+ *                  the full content.
+ * @returns Pruned string that measures ≤ budget tokens.
+ */
+export function applyTokenBudget(
+	content: string,
+	budget: number,
+	query?: string,
+	url?: string,
+): string {
+	const effectiveBudget = Math.max(100, Math.floor(budget));
+	if (estimateTokens(content) <= effectiveBudget) return content;
+
+	// Extract heading skeleton — always preserved in the output.
+	const headingLines = content
+		.split("\n")
+		.filter((l) => /^#{1,6}\s/.test(l));
+
+	// Use pruneMarkdown to select sections within budget.
+	// Reserve tokens for the footer so the guarantee is hard after we append it.
+	const FOOTER_TOKEN_RESERVE = 30;
+	const contentBudget = Math.max(1, effectiveBudget - FOOTER_TOKEN_RESERVE);
+
+	const pruned = pruneMarkdown(content, {
+		maxTokens: contentBudget,
+		query,
+		// When a query is present, drop lowest-BM25 sections first (the
+		// default pruneMarkdown behaviour). Without a query the heuristic
+		// scorer drops lower-priority sections first, which effectively
+		// preserves the top of the document.
+	});
+
+	// Count sections in the original vs kept.
+	const originalSections = splitSections(content);
+	const prunedSections = splitSections(pruned.content);
+	const omitted = Math.max(0, originalSections.length - prunedSections.length);
+
+	const retrieveHint = url
+		? `retrieve via aio-webcontent with URL: ${url}`
+		: "retrieve via aio-webcontent by URL";
+
+	const footer =
+		omitted > 0
+			? `\n\n---\n_truncated to fit ${effectiveBudget}-token budget: ${omitted} section${omitted === 1 ? "" : "s"} omitted; full content cached — ${retrieveHint}._`
+			: `\n\n---\n_content fits ${effectiveBudget}-token budget; full content cached — ${retrieveHint}._`;
+
+	// Preserve heading skeleton even when most content was dropped.
+	// Prepend skeleton if none of the headings survived pruning.
+	let result = pruned.content;
+	if (headingLines.length > 0) {
+		const resultHasHeadings = /^#{1,6}\s/m.test(result);
+		if (!resultHasHeadings) {
+			const skeleton = headingLines.join("\n");
+			result = `${skeleton}\n\n${result}`;
+		}
+	}
+
+	result = result + footer;
+
+	// Hard guarantee: re-measure and trim character-level if still over.
+	if (estimateTokens(result) > effectiveBudget) {
+		// Trim content portion only, keep footer.
+		const footerIdx = result.lastIndexOf("\n\n---\n");
+		const body = footerIdx > 0 ? result.slice(0, footerIdx) : result;
+		const ft = footerIdx > 0 ? result.slice(footerIdx) : "";
+		const footerTokens = estimateTokens(ft);
+		const bodyBudget = Math.max(0, effectiveBudget - footerTokens);
+		const trimmedBody = truncateToBudget(body, bodyBudget);
+		result = trimmedBody + ft;
+	}
+
+	return result;
 }
 
 /**

--- a/src/tools/webcontent.ts
+++ b/src/tools/webcontent.ts
@@ -1,6 +1,7 @@
 import { Type } from "typebox";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getStoredContent } from "../session-store.ts";
+import { applyTokenBudget } from "../prune-markdown.ts";
 
 export function registerWebcontentTool(pi: ExtensionAPI): void {
 	pi.registerTool({
@@ -16,6 +17,19 @@ export function registerWebcontentTool(pi: ExtensionAPI): void {
 			url: Type.String({
 				description: "URL of previously fetched content",
 			}),
+			budgetTokens: Type.Optional(
+				Type.Number({
+					description:
+						"Hard token budget for the content returned to the agent. When set, the output is guaranteed to fit within this many tokens — heading structure is preserved, lowest-value sections are dropped first, and a footer notes how many sections were omitted. Min 100.",
+					minimum: 100,
+				}),
+			),
+			query: Type.Optional(
+				Type.String({
+					description:
+						"Relevance query for budget-aware pruning. When set alongside budgetTokens, sections are scored by BM25 relevance so the most relevant sections are kept.",
+				}),
+			),
 		}),
 
 		async execute(_toolCallId: string, params: any): Promise<any> {
@@ -31,12 +45,17 @@ export function registerWebcontentTool(pi: ExtensionAPI): void {
 					details: { found: false },
 				};
 			}
+			const budgetTokens = params.budgetTokens as number | undefined;
+			const query = params.query as string | undefined;
+			const displayContent = budgetTokens
+				? applyTokenBudget(stored.content, budgetTokens, query, stored.url)
+				: stored.content;
 			const text = [
 				`Retrieved content for ${stored.url}`,
 				stored.title ? `Title: ${stored.title}` : "",
 				`Length: ${stored.content.length} chars`,
 				"\n---\n",
-				stored.content,
+				displayContent,
 			]
 				.filter(Boolean)
 				.join("\n");
@@ -48,6 +67,7 @@ export function registerWebcontentTool(pi: ExtensionAPI): void {
 					url: stored.url,
 					timestamp: stored.timestamp,
 					length: stored.content.length,
+					budgeted: budgetTokens !== undefined,
 				},
 			};
 		},

--- a/src/tools/webfetch.ts
+++ b/src/tools/webfetch.ts
@@ -20,7 +20,7 @@ import {
 	extractInteractables,
 	formatInteractablesSection,
 } from "../interactive-elements.ts";
-import { pruneMarkdown } from "../prune-markdown.ts";
+import { pruneMarkdown, applyTokenBudget } from "../prune-markdown.ts";
 import { createBM25Scorer } from "../bm25.ts";
 import {
 	BASE_TEMP,
@@ -431,6 +431,13 @@ export function registerWebfetchTool(pi: ExtensionAPI): void {
 					description:
 						"Tokens of tail-overlap from the previous chunk prepended to each chunk after the first. Default 50. Only used when chunks: true. Min 0.",
 					minimum: 0,
+				}),
+			),
+			budgetTokens: Type.Optional(
+				Type.Number({
+					description:
+						"Hard token budget for the content returned to the agent. When set, the output is guaranteed to fit within this many tokens — heading structure is preserved, lowest-value sections are dropped first (BM25-scored when query is also set), and a footer notes how many sections were omitted. Composes with query answer mode: the budget is applied to the answer-mode output. Full content is always cached before trimming. Min 100.",
+					minimum: 100,
 				}),
 			),
 		}),
@@ -1060,7 +1067,11 @@ export function registerWebfetchTool(pi: ExtensionAPI): void {
 							summaryNotice = r.outPath
 								? `\n[Answer mode: top ${topK} chunks for "${answerModeQuery}". Full content (${preview.length} chars) saved to ${r.outPath}.]`
 								: `\n[Answer mode: top ${topK} chunks for "${answerModeQuery}". Full content cached (result ID ${responseId ?? "unavailable"}).]`;
-							displayContent = answerBody;
+							// Apply hard token budget after answer mode (composes cleanly).
+							const budgetTokens = params.budgetTokens as number | undefined;
+							displayContent = budgetTokens
+								? applyTokenBudget(answerBody, budgetTokens, answerModeQuery, r.url as string | undefined)
+								: answerBody;
 							// Skip the normal summarize/truncate path.
 							const formatLabel =
 								`✓ Fetched and saved to ${r.outPath}${summaryNotice}`;
@@ -1135,6 +1146,19 @@ export function registerWebfetchTool(pi: ExtensionAPI): void {
 							? `\n[Preview truncated: ${preview.length} chars total, ${MAX_PREVIEW_CHARS} chars shown. Use the read tool for full content.]`
 							: `\n[Preview truncated: ${preview.length} chars total, ${MAX_PREVIEW_CHARS} chars shown. Full result ID: ${responseId ?? "unavailable"}.]`;
 						displayContent = preview.slice(0, MAX_PREVIEW_CHARS);
+					}
+
+					// Apply hard token budget to the display content if requested.
+					// Full content is already cached above — only the agent-visible
+					// portion is narrowed here. Only applied to markdown format.
+					const budgetTokens = params.budgetTokens as number | undefined;
+					if (budgetTokens && itemFormat === "markdown") {
+						displayContent = applyTokenBudget(
+							displayContent,
+							budgetTokens,
+							params.query as string | undefined,
+							r.url as string | undefined,
+						);
 					}
 
 					// For non-markdown formats, the content is in the response-id cache

--- a/tests/token-budget.test.mjs
+++ b/tests/token-budget.test.mjs
@@ -96,7 +96,11 @@ test("applyTokenBudget: footer includes url when provided", () => {
 	]);
 	const url = "https://example.com/article";
 	const result = applyTokenBudget(doc, 100, undefined, url);
-	assert.ok(result.includes(url), "footer should include the provided URL");
+	assert.match(
+		result,
+		/retrieve via aio-webcontent with URL: https:\/\/example\.com\/article/,
+		"footer should include the provided URL",
+	);
 });
 
 test("applyTokenBudget: footer mentions sections omitted count", () => {

--- a/tests/token-budget.test.mjs
+++ b/tests/token-budget.test.mjs
@@ -1,0 +1,216 @@
+// ─── Tests for hard token-budget contract (issue #44) ────────────────
+//
+// Covers applyTokenBudget():
+//   - No-op when content already fits the budget
+//   - Budget is respected (measured tokens ≤ budget)
+//   - Heading skeleton is preserved even when most content is dropped
+//   - Footer is present (format: "N-token budget", "sections omitted", aio-webcontent)
+//   - Composes with applyQueryAnswerMode output
+//   - Hard guarantee on pathological input (one giant section)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { applyTokenBudget } from "../src/prune-markdown.ts";
+import { applyQueryAnswerMode } from "../src/tools/webfetch.ts";
+import { estimateTokens } from "../src/token-count.ts";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/** Make a multi-section markdown doc with known token sizes. */
+function makeDoc(sections) {
+	return sections
+		.map(({ heading, body }) => `## ${heading}\n\n${body}`)
+		.join("\n\n");
+}
+
+/** Repeat a word N times to produce a roughly-N-token body. */
+function words(word, count) {
+	return Array(count).fill(word).join(" ");
+}
+
+// ─── No-op when already within budget ────────────────────────────────
+
+test("applyTokenBudget: no-op when content fits", () => {
+	const content = "## Hello\n\nShort content.";
+	const result = applyTokenBudget(content, 5000);
+	assert.equal(result, content, "content should be unchanged when under budget");
+});
+
+// ─── Budget is respected ──────────────────────────────────────────────
+
+test("applyTokenBudget: output fits within budget", () => {
+	const doc = makeDoc([
+		{ heading: "Intro", body: words("alpha", 200) },
+		{ heading: "Details", body: words("beta", 200) },
+		{ heading: "More", body: words("gamma", 200) },
+		{ heading: "Extra", body: words("delta", 200) },
+	]);
+
+	const budget = 300;
+	const result = applyTokenBudget(doc, budget);
+	const resultTokens = estimateTokens(result);
+	assert.ok(
+		resultTokens <= budget,
+		`output tokens ${resultTokens} should be ≤ budget ${budget}`,
+	);
+});
+
+// ─── Heading skeleton preserved ───────────────────────────────────────
+
+test("applyTokenBudget: heading skeleton preserved when content is heavily pruned", () => {
+	// Very tight budget so all body content must be dropped
+	const headings = ["Introduction", "Details", "Pricing", "FAQ"];
+	const doc = makeDoc(
+		headings.map((h) => ({ heading: h, body: words("word", 100) })),
+	);
+
+	const budget = 120; // Only enough for a few lines
+	const result = applyTokenBudget(doc, budget);
+
+	// At least one heading should survive (or skeleton prepended)
+	const hasHeading = /^#{1,6}\s/m.test(result);
+	assert.ok(hasHeading, "result should contain at least one heading");
+});
+
+// ─── Footer is present ───────────────────────────────────────────────
+
+test("applyTokenBudget: footer present when content is trimmed", () => {
+	const doc = makeDoc([
+		{ heading: "A", body: words("alpha", 100) },
+		{ heading: "B", body: words("beta", 100) },
+		{ heading: "C", body: words("gamma", 100) },
+	]);
+
+	const budget = 150;
+	const result = applyTokenBudget(doc, budget);
+
+	// Footer should contain budget reference and aio-webcontent hint
+	assert.ok(result.includes("token budget"), `footer should mention token budget; got: ${result.slice(-200)}`);
+	assert.ok(result.includes("aio-webcontent"), `footer should mention aio-webcontent; got: ${result.slice(-200)}`);
+});
+
+test("applyTokenBudget: footer includes url when provided", () => {
+	const doc = makeDoc([
+		{ heading: "A", body: words("alpha", 100) },
+		{ heading: "B", body: words("beta", 100) },
+	]);
+	const url = "https://example.com/article";
+	const result = applyTokenBudget(doc, 100, undefined, url);
+	assert.ok(result.includes(url), "footer should include the provided URL");
+});
+
+test("applyTokenBudget: footer mentions sections omitted count", () => {
+	const doc = makeDoc([
+		{ heading: "A", body: words("alpha", 80) },
+		{ heading: "B", body: words("beta", 80) },
+		{ heading: "C", body: words("gamma", 80) },
+	]);
+
+	const budget = 100;
+	const result = applyTokenBudget(doc, budget);
+	assert.ok(
+		/\d+ section/.test(result),
+		"footer should mention how many sections were omitted",
+	);
+});
+
+// ─── Composition with query answer mode ──────────────────────────────
+
+test("applyTokenBudget: composes with applyQueryAnswerMode output", () => {
+	const doc = makeDoc([
+		{
+			heading: "Pricing",
+			body: "Our pricing plans include Free Pro and Enterprise tiers. Monthly billing available.",
+		},
+		{
+			heading: "Installation",
+			body: words("install setup download wizard", 60),
+		},
+		{
+			heading: "Support",
+			body: words("help contact email chat", 60),
+		},
+	]);
+
+	// First apply answer mode
+	const answerBody = applyQueryAnswerMode(doc, "pricing billing", 2, {
+		maxTokens: 50,
+	});
+	assert.ok(answerBody !== undefined, "answer mode should produce output");
+
+	// Then apply budget to the answer-mode output
+	const budget = 100;
+	const result = applyTokenBudget(answerBody, budget, "pricing billing");
+	const resultTokens = estimateTokens(result);
+	assert.ok(
+		resultTokens <= budget,
+		`budget should be respected after answer mode; got ${resultTokens} > ${budget}`,
+	);
+});
+
+// ─── Hard guarantee: pathological input (one giant section) ──────────
+
+test("applyTokenBudget: hard guarantee with one giant section (no headings)", () => {
+	// A single huge paragraph with no markdown headings — the worst case
+	// because there are no section boundaries to prune at.
+	const giant = words("word", 2000);
+	const budget = 200;
+	const result = applyTokenBudget(giant, budget);
+	const resultTokens = estimateTokens(result);
+	assert.ok(
+		resultTokens <= budget,
+		`hard guarantee violated: ${resultTokens} tokens > budget ${budget}`,
+	);
+});
+
+test("applyTokenBudget: hard guarantee with one giant section under a heading", () => {
+	const giant = `## Giant Section\n\n${words("word", 2000)}`;
+	const budget = 200;
+	const result = applyTokenBudget(giant, budget);
+	const resultTokens = estimateTokens(result);
+	assert.ok(
+		resultTokens <= budget,
+		`hard guarantee violated: ${resultTokens} tokens > budget ${budget}`,
+	);
+});
+
+// ─── Minimum budget floor ─────────────────────────────────────────────
+
+test("applyTokenBudget: minimum budget floor is 100", () => {
+	const doc = makeDoc([{ heading: "A", body: words("word", 50) }]);
+	// Passing budget < 100 should be floored to 100
+	const result = applyTokenBudget(doc, 10);
+	// Should not throw, and should produce some output
+	assert.ok(typeof result === "string" && result.length > 0);
+});
+
+// ─── No change when budgetTokens absent ──────────────────────────────
+
+test("applyTokenBudget: content unchanged when content fits budget", () => {
+	const small = "## Title\n\nA short paragraph.";
+	const result = applyTokenBudget(small, 10000);
+	assert.equal(result, small);
+});
+
+// ─── BM25 ordering when query provided ───────────────────────────────
+
+test("applyTokenBudget: keeps most relevant section when query provided", () => {
+	const doc = makeDoc([
+		{ heading: "Pricing", body: "monthly billing subscription price cost plans tiers free pro enterprise" },
+		{ heading: "Installation", body: words("install setup wizard download", 30) },
+		{ heading: "Support", body: words("help contact email phone", 30) },
+	]);
+
+	// Very tight budget, only one section worth of content should survive
+	const budget = 60;
+	const result = applyTokenBudget(doc, budget, "pricing billing cost");
+	// The pricing section should be preferred over others
+	assert.ok(
+		result.toLowerCase().includes("pricing") ||
+		result.toLowerCase().includes("billing") ||
+		result.toLowerCase().includes("price"),
+		`expected pricing content to be kept; result: ${result}`,
+	);
+	const resultTokens = estimateTokens(result);
+	assert.ok(resultTokens <= budget, `budget violated: ${resultTokens} > ${budget}`);
+});


### PR DESCRIPTION
Closes #44.

Adds an optional `budgetTokens` parameter to `aio-webfetch` and `aio-webcontent` that guarantees output never exceeds the given token budget.

- New `applyTokenBudget` in `src/prune-markdown.ts`, reusing `pruneMarkdown`/`splitSections` (now exported) — BM25-guided section dropping when a `query` is present, heuristic otherwise
- Heading skeleton preserved even when all sections are dropped
- Hard guarantee: output is re-measured after pruning and force-truncated if still over, footer included in the budget
- Composes with #42 answer mode (budget applies after chunk selection); full content still cached before trimming
- Named `budgetTokens` to avoid colliding with the existing `maxTokens` chunk-size param
- 12 new tests in `tests/token-budget.test.mjs`; full suite and tsc pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)