### PR TITLE
feat: aio-webquery — local BM25 search over webpull corpora

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ extract, map, cache, chunk, and render web content for AI agents.
 
 ## What It Does
 
-pi-webaio registers six pi tools:
+pi-webaio registers seven pi tools:
 
 - `aio-websearch` — search DuckDuckGo, Brave, Yahoo, Bing, and Google in parallel
 - `aio-webfetch` — fetch one or many URLs into markdown or structured formats
@@ -17,6 +17,7 @@ pi-webaio registers six pi tools:
 - `aio-webresult` — retrieve cached results by response ID
 - `aio-webmap` — discover site pages or map GitHub repositories without fetching
 - `aio-webpull` — crawl/pull sites into local markdown files
+- `aio-webquery` — BM25 search over a locally-pulled corpus (offline, no re-fetching)
 
 It includes anti-bot TLS fingerprinting, browser fallback, GitHub/YouTube/package
 registry extractors, RAG chunking, TUI progress rendering, phase-aware errors,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -13,7 +13,8 @@ Registered pi tools and parameters provided by pi-webaio.
 | `aio-webcontent` | Retrieve previously fetched content from session storage by URL. Returns **full untruncated content** — no data loss.                                                                                                                                                                                                                 |
 | `aio-webmap`     | Discovery-only tool — finds pages via robots.txt, sitemaps, navigation links, and llms.txt without fetching content. Returns structured URL list.                                                                                                                                                                                     |
 | `aio-webresult`  | Retrieve a previously fetched result by persistent response ID. Survives restarts. Shows recent results if ID not found.                                                                                                                                                                                                              |
-| `aio-webpull`    | Pull any public website or docs site into local markdown files. Discovers pages via sitemap, navigation links, or crawling. Rewrites internal links to relative `.md` paths. Supports `routes` for per-pattern routing, `resume` for checkpoint resume, `adaptive` selectors, and `bypass` for opt-in paywall bypass on every page.       |
+| `aio-webpull`    | Pull any public website or docs site into local markdown files. Discovers pages via sitemap, navigation links, or crawling. Rewrites internal links to relative `.md` paths. Supports `routes` for per-pattern routing, `resume` for checkpoint resume, `adaptive` selectors, and `bypass` for opt-in paywall bypass on every page. Automatically builds a BM25 index for offline search. |
+| `aio-webquery`   | BM25 full-text search over a corpus pulled by `aio-webpull`. No re-fetching — purely local, offline retrieval. Returns top-k chunks with source file, original URL, and heading breadcrumb. Requires running `aio-webpull` first to build the index.                                                                                   |
 
 ### Tool Parameters
 
@@ -86,3 +87,11 @@ Registered pi tools and parameters provided by pi-webaio.
 | `resume`  | `boolean` | `true`       | Resume from previous pull (auto-detected from output directory). Set `false` to force a fresh pull.   |
 | `routes`  | `object[]`| —            | URL pattern → fetcher mode routing. Each: `{ pattern: string, mode?: string, browser?: string, os?: string, extractor?: string }`. Pattern supports substring, glob (`*/docs/*`), or regex (`/^\/api\//`). First match wins. |
 | `adaptive`| `boolean` | `false`      | Enable adaptive content selectors that survive site redesigns via structural DOM fingerprinting.       |
+
+#### `aio-webquery`
+
+| Parameter | Type     | Default              | Description                                                                                         |
+| --------- | -------- | -------------------- | --------------------------------------------------------------------------------------------------- |
+| `query`   | `string` | —                    | Search query to run against the local corpus                                                        |
+| `dir`     | `string` | `<os-temp>/pi-webaio`| Directory containing a pulled corpus (output of `aio-webpull`). Defaults to the standard temp base. |
+| `topK`    | `number` | `8`                  | Number of top-ranked chunks to return                                                               |

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import { registerWebresultTool } from "./src/tools/webresult.ts";
 import { registerWebsearchTool } from "./src/tools/websearch.ts";
 import { registerWebmapTool } from "./src/tools/webmap.ts";
 import { registerWebpullTool } from "./src/tools/webpull.ts";
+import { registerWebqueryTool } from "./src/tools/webquery.ts";
 
 export default function (pi: ExtensionAPI) {
 	// Load persisted search cache on startup
@@ -25,11 +26,12 @@ export default function (pi: ExtensionAPI) {
 	// killed because the ref'd interval keeps the loop running.
 	setInterval(cleanupSessionCache, SESSION_CACHE_CLEANUP_MS).unref();
 
-	// Register all 6 tools
+	// Register all 7 tools
 	registerWebfetchTool(pi);
 	registerWebcontentTool(pi);
 	registerWebresultTool(pi);
 	registerWebsearchTool(pi);
 	registerWebmapTool(pi);
 	registerWebpullTool(pi);
+	registerWebqueryTool(pi);
 }

--- a/src/tools/webpull.ts
+++ b/src/tools/webpull.ts
@@ -19,6 +19,7 @@ import {
 	rewriteLinks,
 	runPullFromQueue,
 } from "./utils.ts";
+import { buildIndex } from "../webquery-index.ts";
 
 const MAX_CRAWL_ITEMS = 500;
 
@@ -392,9 +393,22 @@ export function registerWebpullTool(pi: ExtensionAPI): void {
 				}
 			}
 
+			// Build BM25 index from all markdown files currently on disk.
+			// A full rebuild keeps the index consistent even after resume/append pulls.
+			let indexBuilt = false;
+			if (ok > 0) {
+				try {
+					await buildIndex(outDir);
+					indexBuilt = true;
+				} catch {
+					/* best effort — pull result is still valid */
+				}
+			}
+
 			const summary = [
 				`✅ Pulled ${ok} pages to ${outDir}`,
 				err > 0 ? `⚠️ ${err} pages failed` : "",
+				indexBuilt ? `🔍 BM25 index built — use aio-webquery to search this corpus` : "",
 				``,
 				`Files:`,
 				...files.slice(0, 30).map((f) => `  - ${f}`),
@@ -466,6 +480,7 @@ export function registerWebpullTool(pi: ExtensionAPI): void {
 					proxy,
 					packagePath,
 					adaptive,
+					indexBuilt,
 					queueStats: queue?.stats(),
 					browserPoolStats: browserPool?.stats(),
 				},

--- a/src/tools/webquery.ts
+++ b/src/tools/webquery.ts
@@ -1,0 +1,135 @@
+import { join } from "node:path";
+import { Type } from "typebox";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { tmpdir } from "node:os";
+import { createBM25Scorer } from "../bm25.ts";
+import { loadIndex } from "../webquery-index.ts";
+
+/** Default output directory matches webpull's default: <os-temp>/pi-webaio/<hostname> */
+const DEFAULT_BASE = join(tmpdir(), "pi-webaio");
+
+export function registerWebqueryTool(pi: ExtensionAPI): void {
+	pi.registerTool({
+		name: "aio-webquery",
+		label: "Web Query",
+		description:
+			"Search a locally-pulled website corpus (from aio-webpull) using BM25. No re-fetching — offline, token-cheap knowledge base retrieval. Returns top-k relevant chunks with source file, original URL, and heading breadcrumb.",
+		promptSnippet: "Search pulled docs locally with BM25",
+		promptGuidelines: [
+			"Use aio-webquery to search content previously pulled with aio-webpull without re-downloading anything.",
+			"Use aio-webpull first if no index exists yet — it will build the BM25 index automatically.",
+			"Use aio-websearch or aio-webfetch for live web searches instead.",
+		],
+		parameters: Type.Object({
+			query: Type.String({
+				description: "Search query to run against the local corpus",
+			}),
+			dir: Type.Optional(
+				Type.String({
+					description: `Directory containing a pulled corpus (output of aio-webpull). Defaults to the standard temp location: ${DEFAULT_BASE}/<hostname>`,
+				}),
+			),
+			topK: Type.Optional(
+				Type.Number({
+					description: "Number of top chunks to return (default: 8)",
+					default: 8,
+				}),
+			),
+		}),
+
+		async execute(_toolCallId: string, params: any): Promise<any> {
+			const query: string = params.query;
+			const topK: number =
+				Number.isFinite(params.topK) && params.topK > 0
+					? Math.floor(params.topK)
+					: 8;
+
+			// Resolve directory
+			const dir: string = params.dir ?? DEFAULT_BASE;
+
+			// Load the index
+			const loaded = await loadIndex(dir);
+			if (!loaded.ok) {
+				return {
+					content: [{ type: "text", text: loaded.message }],
+					details: { found: false, reason: loaded.reason, dir },
+				};
+			}
+
+			const { index } = loaded;
+			const { chunks } = index;
+
+			if (chunks.length === 0) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `The index at ${dir} exists but contains no chunks. The pulled corpus may be empty.`,
+						},
+					],
+					details: { found: true, chunkCount: 0, dir },
+				};
+			}
+
+			// Score all chunks with BM25
+			const scorer = createBM25Scorer(query);
+			const texts = chunks.map((c) => c.text);
+			const scores = scorer.scoreAll(texts);
+
+			// Rank and select top-k
+			const ranked = scores
+				.map((score, i) => ({ score, chunk: chunks[i]! }))
+				.filter((r) => r.score > 0)
+				.sort((a, b) => b.score - a.score)
+				.slice(0, topK);
+
+			if (ranked.length === 0) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `No relevant chunks found for query: "${query}"\n\nThe corpus at ${dir} has ${chunks.length} indexed chunks but none matched the query terms.`,
+						},
+					],
+					details: { found: true, chunkCount: chunks.length, matchCount: 0, dir },
+				};
+			}
+
+			// Format output
+			const lines: string[] = [
+				`Found ${ranked.length} relevant chunk${ranked.length === 1 ? "" : "s"} (of ${chunks.length} indexed) for: "${query}"`,
+				`Corpus: ${dir}  |  Built: ${index.builtAt}`,
+				"",
+			];
+
+			for (let i = 0; i < ranked.length; i++) {
+				const { score, chunk } = ranked[i]!;
+				const heading = chunk.heading ? ` › ${chunk.heading}` : "";
+				lines.push(`--- [${i + 1}/${ranked.length}] score=${score.toFixed(3)} ---`);
+				lines.push(`File: ${chunk.file}${heading}`);
+				if (chunk.url) lines.push(`URL: ${chunk.url}`);
+				lines.push("");
+				lines.push(chunk.text);
+				lines.push("");
+			}
+
+			return {
+				content: [{ type: "text", text: lines.join("\n") }],
+				details: {
+					found: true,
+					query,
+					dir,
+					chunkCount: chunks.length,
+					matchCount: ranked.length,
+					builtAt: index.builtAt,
+					results: ranked.map(({ score, chunk }) => ({
+						score,
+						file: chunk.file,
+						url: chunk.url,
+						heading: chunk.heading,
+					})),
+				},
+			};
+		},
+	});
+}

--- a/src/webquery-index.ts
+++ b/src/webquery-index.ts
@@ -1,0 +1,193 @@
+// ─── BM25 index builder and loader for aio-webpull corpus ────────────
+// Serializes per-chunk metadata into a compact JSON file alongside the
+// pulled markdown files. Loaded at query time by aio-webquery.
+
+import { readFile, writeFile, readdir, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { chunkMarkdown } from "./chunker.ts";
+
+/** Index format version — bump when the stored shape changes. */
+export const INDEX_VERSION = 1;
+
+/** Name of the index file written into the output directory. */
+export const INDEX_FILENAME = ".webaio-index.json";
+
+/** One indexed chunk stored in the JSON file. */
+export interface IndexedChunk {
+	/** Relative path from outDir to the source markdown file. */
+	file: string;
+	/** Original URL from YAML frontmatter. */
+	url: string;
+	/** Heading breadcrumb derived from the chunk (first # heading found). */
+	heading: string;
+	/** The chunk text itself. */
+	text: string;
+}
+
+/** Full index file structure. */
+export interface WebpullIndex {
+	version: number;
+	/** ISO timestamp of the last build. */
+	builtAt: string;
+	/** Absolute path of the output directory at build time. */
+	outDir: string;
+	chunks: IndexedChunk[];
+}
+
+// ─── Index building ────────────────────────────────────────────────────
+
+/**
+ * Extract the source URL from YAML frontmatter in a markdown file.
+ * Returns an empty string if no frontmatter is found.
+ */
+function extractFrontmatterUrl(markdown: string): string {
+	const match = markdown.match(/^---\n[\s\S]*?^url:\s*"?([^"\n]+)"?\s*$/m);
+	return match ? match[1].trim() : "";
+}
+
+/**
+ * Extract the first H1/H2 heading from a chunk of text as a breadcrumb.
+ */
+function extractHeading(text: string): string {
+	const match = text.match(/^#{1,6}\s+(.+)$/m);
+	return match ? match[1].trim() : "";
+}
+
+/**
+ * Walk `outDir` recursively and collect all `.md` files.
+ */
+async function collectMarkdownFiles(outDir: string): Promise<string[]> {
+	const results: string[] = [];
+	async function walk(dir: string): Promise<void> {
+		let entries: string[];
+		try {
+			entries = await readdir(dir);
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			if (entry.startsWith(".")) continue; // skip hidden files/dirs
+			const full = join(dir, entry);
+			let info;
+			try {
+				info = await stat(full);
+			} catch {
+				continue;
+			}
+			if (info.isDirectory()) {
+				await walk(full);
+			} else if (entry.endsWith(".md")) {
+				results.push(full);
+			}
+		}
+	}
+	await walk(outDir);
+	return results;
+}
+
+/**
+ * Build a BM25 index from all markdown files currently on disk in `outDir`.
+ * Writes the result to `<outDir>/.webaio-index.json`.
+ *
+ * This does a full rebuild — safe to call after any pull (incremental or fresh).
+ */
+export async function buildIndex(outDir: string): Promise<void> {
+	const allFiles = await collectMarkdownFiles(outDir);
+	const chunks: IndexedChunk[] = [];
+
+	for (const fullPath of allFiles) {
+		let markdown: string;
+		try {
+			markdown = await readFile(fullPath, "utf8");
+		} catch {
+			continue;
+		}
+
+		const url = extractFrontmatterUrl(markdown);
+		const rel = relative(outDir, fullPath).replace(/\\/g, "/");
+
+		const fileChunks = chunkMarkdown(markdown, {
+			maxTokens: 512,
+			overlapTokens: 50,
+		});
+
+		for (const chunk of fileChunks) {
+			chunks.push({
+				file: rel,
+				url,
+				heading: extractHeading(chunk.text),
+				text: chunk.text,
+			});
+		}
+	}
+
+	const index: WebpullIndex = {
+		version: INDEX_VERSION,
+		builtAt: new Date().toISOString(),
+		outDir,
+		chunks,
+	};
+
+	await writeFile(
+		join(outDir, INDEX_FILENAME),
+		JSON.stringify(index),
+		"utf8",
+	);
+}
+
+// ─── Index loading ─────────────────────────────────────────────────────
+
+export type LoadIndexResult =
+	| { ok: true; index: WebpullIndex }
+	| { ok: false; reason: "missing" | "version_mismatch" | "corrupt"; message: string };
+
+/**
+ * Load and validate the index from `outDir`.
+ */
+export async function loadIndex(outDir: string): Promise<LoadIndexResult> {
+	const indexPath = join(outDir, INDEX_FILENAME);
+	let raw: string;
+	try {
+		raw = await readFile(indexPath, "utf8");
+	} catch {
+		return {
+			ok: false,
+			reason: "missing",
+			message: `No index found at ${indexPath}. Run aio-webpull on this directory first to build the index.`,
+		};
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return {
+			ok: false,
+			reason: "corrupt",
+			message: `Index file at ${indexPath} is corrupt (invalid JSON). Re-run aio-webpull to rebuild it.`,
+		};
+	}
+
+	if (
+		typeof parsed !== "object" ||
+		parsed === null ||
+		!("version" in parsed)
+	) {
+		return {
+			ok: false,
+			reason: "corrupt",
+			message: `Index file at ${indexPath} is missing required fields. Re-run aio-webpull to rebuild it.`,
+		};
+	}
+
+	const obj = parsed as Record<string, unknown>;
+	if (obj["version"] !== INDEX_VERSION) {
+		return {
+			ok: false,
+			reason: "version_mismatch",
+			message: `Index version mismatch (found ${obj["version"]}, expected ${INDEX_VERSION}). Re-run aio-webpull to rebuild the index.`,
+		};
+	}
+
+	return { ok: true, index: parsed as WebpullIndex };
+}

--- a/tests/webquery.test.mjs
+++ b/tests/webquery.test.mjs
@@ -1,0 +1,253 @@
+// ─── Tests for aio-webquery: BM25 index build and search ─────────────
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir as osTmpdir } from "node:os";
+import {
+	buildIndex,
+	loadIndex,
+	INDEX_VERSION,
+	INDEX_FILENAME,
+} from "../src/webquery-index.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+async function makeTempDir() {
+	return mkdtemp(join(osTmpdir(), "webquery-test-"));
+}
+
+/**
+ * Write a minimal markdown file with YAML frontmatter into `dir`.
+ */
+async function writeMd(dir, relPath, url, body) {
+	const full = join(dir, relPath);
+	await mkdir(join(dir, relPath.split("/").slice(0, -1).join("/")), {
+		recursive: true,
+	});
+	const content = `---\ntitle: "Test"\nurl: "${url}"\n---\n\n${body}`;
+	await writeFile(full, content, "utf8");
+}
+
+// ─── buildIndex ───────────────────────────────────────────────────────
+
+test("buildIndex: creates index file in outDir", async () => {
+	const dir = await makeTempDir();
+	try {
+		await writeMd(dir, "index.md", "https://example.com/", "Hello world. This is a test page about dogs.");
+		await buildIndex(dir);
+		const result = await loadIndex(dir);
+		assert.ok(result.ok, "index should load successfully");
+		assert.equal(result.index.version, INDEX_VERSION);
+		assert.ok(result.index.chunks.length > 0, "should have at least one chunk");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("buildIndex: chunks contain source file, URL, and text", async () => {
+	const dir = await makeTempDir();
+	try {
+		await writeMd(
+			dir,
+			"docs/intro.md",
+			"https://example.com/docs/intro",
+			"## Introduction\n\nThis document explains the introduction to the system.",
+		);
+		await buildIndex(dir);
+		const result = await loadIndex(dir);
+		assert.ok(result.ok);
+		const chunk = result.index.chunks[0];
+		assert.ok(chunk.file.includes("intro.md"), `expected file path in chunk, got: ${chunk.file}`);
+		assert.equal(chunk.url, "https://example.com/docs/intro");
+		assert.ok(chunk.text.length > 0, "chunk text should not be empty");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("buildIndex: extracts heading breadcrumb from chunks", async () => {
+	const dir = await makeTempDir();
+	try {
+		await writeMd(
+			dir,
+			"guide.md",
+			"https://example.com/guide",
+			"## Getting Started\n\nFollow these steps to get started with the API.",
+		);
+		await buildIndex(dir);
+		const result = await loadIndex(dir);
+		assert.ok(result.ok);
+		const headingChunk = result.index.chunks.find((c) => c.heading.includes("Getting Started"));
+		assert.ok(headingChunk, "should find a chunk with the heading");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("buildIndex: multiple files are all indexed", async () => {
+	const dir = await makeTempDir();
+	try {
+		await writeMd(dir, "page-a.md", "https://example.com/a", "Content about apples and fruit.");
+		await writeMd(dir, "page-b.md", "https://example.com/b", "Content about bicycles and transport.");
+		await buildIndex(dir);
+		const result = await loadIndex(dir);
+		assert.ok(result.ok);
+		const files = new Set(result.index.chunks.map((c) => c.file));
+		assert.ok(files.has("page-a.md"), "page-a.md should be indexed");
+		assert.ok(files.has("page-b.md"), "page-b.md should be indexed");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("buildIndex: full rebuild on second call keeps index consistent", async () => {
+	const dir = await makeTempDir();
+	try {
+		await writeMd(dir, "v1.md", "https://example.com/v1", "Version one content.");
+		await buildIndex(dir);
+		const r1 = await loadIndex(dir);
+		assert.ok(r1.ok);
+		const countAfterFirst = r1.index.chunks.length;
+
+		// Add a second file, rebuild
+		await writeMd(dir, "v2.md", "https://example.com/v2", "Version two content.");
+		await buildIndex(dir);
+		const r2 = await loadIndex(dir);
+		assert.ok(r2.ok);
+		assert.ok(
+			r2.index.chunks.length > countAfterFirst,
+			"second build should include more chunks",
+		);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+// ─── loadIndex ────────────────────────────────────────────────────────
+
+test("loadIndex: returns missing error when no index file", async () => {
+	const dir = await makeTempDir();
+	try {
+		const result = await loadIndex(dir);
+		assert.ok(!result.ok);
+		assert.equal(result.reason, "missing");
+		assert.ok(result.message.includes("aio-webpull"), "message should mention aio-webpull");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("loadIndex: returns corrupt error for invalid JSON", async () => {
+	const dir = await makeTempDir();
+	try {
+		await writeFile(join(dir, INDEX_FILENAME), "not json!!!", "utf8");
+		const result = await loadIndex(dir);
+		assert.ok(!result.ok);
+		assert.equal(result.reason, "corrupt");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("loadIndex: returns version_mismatch for wrong version", async () => {
+	const dir = await makeTempDir();
+	try {
+		const badIndex = { version: 999, builtAt: new Date().toISOString(), outDir: dir, chunks: [] };
+		await writeFile(join(dir, INDEX_FILENAME), JSON.stringify(badIndex), "utf8");
+		const result = await loadIndex(dir);
+		assert.ok(!result.ok);
+		assert.equal(result.reason, "version_mismatch");
+		assert.ok(result.message.includes("Re-run aio-webpull"), "message should tell user to re-pull");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("loadIndex: returns corrupt error for missing version field", async () => {
+	const dir = await makeTempDir();
+	try {
+		const badIndex = { builtAt: new Date().toISOString(), chunks: [] };
+		await writeFile(join(dir, INDEX_FILENAME), JSON.stringify(badIndex), "utf8");
+		const result = await loadIndex(dir);
+		assert.ok(!result.ok);
+		assert.equal(result.reason, "corrupt");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+// ─── BM25 query relevance ─────────────────────────────────────────────
+
+test("query returns relevant chunks with attribution", async () => {
+	const dir = await makeTempDir();
+	try {
+		await writeMd(
+			dir,
+			"dogs.md",
+			"https://example.com/dogs",
+			"Dogs are loyal animals. They make great companions and are known for their playfulness.",
+		);
+		await writeMd(
+			dir,
+			"cats.md",
+			"https://example.com/cats",
+			"Cats are independent creatures. They are known for their agility and self-sufficiency.",
+		);
+		await buildIndex(dir);
+
+		const { createBM25Scorer } = await import("../src/bm25.ts");
+		const result = await loadIndex(dir);
+		assert.ok(result.ok);
+
+		const scorer = createBM25Scorer("loyal dog companions");
+		const scores = scorer.scoreAll(result.index.chunks.map((c) => c.text));
+		const ranked = scores
+			.map((score, i) => ({ score, chunk: result.index.chunks[i] }))
+			.filter((r) => r.score > 0)
+			.sort((a, b) => b.score - a.score);
+
+		assert.ok(ranked.length > 0, "should find at least one relevant chunk");
+		// The dog page should rank above the cat page for a dogs-related query
+		const topChunk = ranked[0].chunk;
+		assert.ok(
+			topChunk.url === "https://example.com/dogs",
+			`top result should be the dogs page, got: ${topChunk.url}`,
+		);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("topK limits the number of results", async () => {
+	const dir = await makeTempDir();
+	try {
+		// Write many pages
+		for (let i = 0; i < 10; i++) {
+			await writeMd(
+				dir,
+				`page-${i}.md`,
+				`https://example.com/page-${i}`,
+				`Page ${i} talks about programming languages and software development techniques.`,
+			);
+		}
+		await buildIndex(dir);
+		const { createBM25Scorer } = await import("../src/bm25.ts");
+		const result = await loadIndex(dir);
+		assert.ok(result.ok);
+
+		const scorer = createBM25Scorer("programming software");
+		const scores = scorer.scoreAll(result.index.chunks.map((c) => c.text));
+		const topK = 3;
+		const ranked = scores
+			.map((score, i) => ({ score, chunk: result.index.chunks[i] }))
+			.filter((r) => r.score > 0)
+			.sort((a, b) => b.score - a.score)
+			.slice(0, topK);
+
+		assert.ok(ranked.length <= topK, `should return at most ${topK} results`);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
Closes #48.

Adds a seventh tool, `aio-webquery`, that searches `aio-webpull` output locally — an offline, token-cheap knowledge base with no re-fetching.

- `aio-webpull` now builds a versioned `.webaio-index.json` in the output dir (full rebuild from all .md files at end of every pull, including resumed pulls, for consistency)
- New `src/webquery-index.ts` (build/load, versioned format) and `src/tools/webquery.ts` (`query`, `dir`, `topK` params)
- Chunks carry source attribution: relative file path, original URL from frontmatter, heading breadcrumb
- Graceful errors: missing index → "run aio-webpull first"; version mismatch → "re-pull to rebuild"
- Docs and README updated (six → seven tools)
- 11 new tests; full suite and tsc pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)