### PR TITLE
feat: user-defined vertical extractors from config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ pi install git:github.com/apmantza/pi-webaio
 
 - [Features](docs/features.md) — overview, extraction pipeline, GitHub/YouTube
   handling, output formats, chunking, errors, and search ranking
+- [Custom vertical extractors](docs/custom-verticals.md) — add your own site
+  extractors (company wikis, niche sites) without forking
 - [Usage guide](docs/usage.md) — common pi prompts and examples
 - [Tools reference](docs/tools.md) — tool names, parameters, and defaults
 - [Architecture](docs/architecture.md) — build, TUI rendering, FetchError system,

--- a/docs/custom-verticals.md
+++ b/docs/custom-verticals.md
@@ -1,0 +1,178 @@
+# Custom Vertical Extractors
+
+pi-webaio ships ~20 built-in site extractors (PyPI, npm, Hacker News, Reddit, …).
+You can add your own extractors for company wikis, niche sites, or anything else
+**without forking the package** — just drop `.mjs` files into a config directory.
+
+---
+
+## Security notice
+
+Files in the config directory are loaded with Node.js `import()` and execute as
+**arbitrary code with the full privileges of the pi-webaio agent process** — the
+same user account, file-system access, network access, and environment variables.
+Only place modules there that you wrote yourself or fully trust.
+
+---
+
+## Config directory
+
+```
+~/.pi/agent/webaio/verticals/
+```
+
+Create the directory if it does not exist:
+
+```sh
+mkdir -p ~/.pi/agent/webaio/verticals
+```
+
+Every `.mjs` file in that directory is loaded at startup. The directory is watched
+only at load time (i.e. restart pi for changes to take effect).
+
+You can override the directory for testing or CI by setting the environment variable:
+
+```sh
+PI_WEBAIO_USER_VERTICALS_DIR=/path/to/my/extractors pi ...
+```
+
+---
+
+## Extractor contract
+
+Each module must **default-export** (or **named-export** as `extractor`) an object
+with the following shape:
+
+```ts
+interface UserExtractorModule {
+  /** Short identifier shown in the "via <name>" attribution line. */
+  name: string;
+
+  /** Return true when this extractor should handle the given URL. */
+  match(url: string): boolean;
+
+  /**
+   * Perform the extraction.
+   * Return a VerticalResult on success, or null to signal "not handled"
+   * (falls through to the built-in HTML pipeline).
+   */
+  extract(
+    url: string,
+    fetchJson: (url: string) => Promise<unknown | null>,
+    fetchText: (url: string) => Promise<string | null>,
+    fetchHtml: (url: string) => Promise<string | null>,
+  ): Promise<VerticalResult | null>;
+}
+
+interface VerticalResult {
+  ok: boolean;
+  url: string;
+  title?: string;
+  content: string;   // Markdown string shown to the agent
+  error?: string;    // Human-readable error message when ok === false
+}
+```
+
+### Fetch helpers
+
+The three helpers passed to `extract` are the same lightweight wrappers used by
+all built-in extractors. They handle retries, timeouts, and the user's proxy
+settings automatically:
+
+| Helper | Returns |
+|---|---|
+| `fetchJson(url)` | Parsed JSON (`unknown`) or `null` on error / non-2xx |
+| `fetchText(url)` | Raw response body as a string, or `null` on error |
+| `fetchHtml(url)` | Raw HTML body as a string, or `null` on error |
+
+---
+
+## Priority
+
+User extractors are checked **before** built-ins. If your extractor matches a URL
+that a built-in also matches (e.g. `pypi.org`), your extractor wins.
+
+If your extractor returns `null`, the built-in pipeline continues normally.
+If your extractor **throws**, pi-webaio catches the error, emits a `[user-verticals]`
+warning to stderr, and falls through to the built-in pipeline — startup is never
+interrupted.
+
+---
+
+## Minimal example (copy-paste ready)
+
+Save as `~/.pi/agent/webaio/verticals/my-wiki.mjs`:
+
+```js
+// ~/.pi/agent/webaio/verticals/my-wiki.mjs
+// Extractor for Acme Corp internal wiki at wiki.acme.internal
+
+export default {
+  name: "acme-wiki",
+
+  match(url) {
+    return /^https?:\/\/wiki\.acme\.internal\//i.test(url);
+  },
+
+  async extract(url, fetchJson, fetchText, fetchHtml) {
+    // Use the REST API exposed by your wiki software, or fetch HTML.
+    const html = await fetchHtml(url);
+    if (!html) return null;
+
+    // Minimal extraction: pull the page title and first <article> block.
+    const titleMatch = html.match(/<title>([^<]+)<\/title>/i);
+    const title = titleMatch ? titleMatch[1].trim() : "Wiki Page";
+
+    const bodyMatch = html.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+    const raw = bodyMatch ? bodyMatch[1] : html;
+
+    // Strip tags for a plain-text approximation.
+    const content = `# ${title}\n\n${raw.replace(/<[^>]+>/g, "").trim()}`;
+
+    return { ok: true, url, title, content };
+  },
+};
+```
+
+### Using a JSON API instead
+
+```js
+export default {
+  name: "acme-issues",
+
+  match(url) {
+    return url.startsWith("https://issues.acme.internal/issue/");
+  },
+
+  async extract(url, fetchJson) {
+    const id = url.split("/issue/")[1];
+    const data = await fetchJson(`https://issues.acme.internal/api/issue/${id}`);
+    if (!data) return null;
+
+    const content = [
+      `# ${data.title}`,
+      `**Status:** ${data.status}  **Reporter:** ${data.reporter}`,
+      "",
+      data.description ?? "_No description_",
+    ].join("\n");
+
+    return { ok: true, url, title: data.title, content };
+  },
+};
+```
+
+---
+
+## Validation
+
+At load time pi-webaio validates each module and **skips** any that fail, printing a
+single warning to stderr like:
+
+```
+[user-verticals] Skipping /home/you/.pi/agent/webaio/verticals/broken.mjs: missing or empty string field "name"
+```
+
+Validation checks:
+- `name` — non-empty string
+- `match` — function, must not throw when called with `"https://example.com/"`
+- `extract` — function

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import {
 	cleanupSessionCache,
 	SESSION_CACHE_CLEANUP_MS,
 } from "./src/session-store.ts";
+import { initUserExtractors } from "./src/verticals/registry.ts";
 import { registerWebfetchTool } from "./src/tools/webfetch.ts";
 import { registerWebcontentTool } from "./src/tools/webcontent.ts";
 import { registerWebresultTool } from "./src/tools/webresult.ts";
@@ -14,6 +15,9 @@ import { registerWebpullTool } from "./src/tools/webpull.ts";
 import { registerWebqueryTool } from "./src/tools/webquery.ts";
 
 export default function (pi: ExtensionAPI) {
+	// Load user-defined vertical extractors from ~/.pi/agent/webaio/verticals/
+	initUserExtractors().catch(() => {});
+
 	// Load persisted search cache on startup
 	loadSearchCacheFromDisk().catch(() => {});
 	// Load persisted content cache from disk (lazy — contents loaded on first access)

--- a/src/verticals/registry.ts
+++ b/src/verticals/registry.ts
@@ -1,7 +1,13 @@
 // ─── Vertical extractor registry ───────────────────────────────────
 // Pattern-matches URLs and routes to API-first extractors for known sites.
+// User-defined extractors (loaded from ~/.pi/agent/webaio/verticals/*.mjs)
+// are consulted BEFORE built-ins so users can override built-in behavior.
 
 import type { VerticalResult } from "./types.ts";
+import {
+	loadUserExtractors,
+	type RegisteredUserExtractor,
+} from "./user-loader.ts";
 import { matchesNpm, extractNpm } from "./npm.ts";
 import { matchesPyPI, extractPyPI } from "./pypi.ts";
 import { matchesHackerNews, extractHackerNews } from "./hackernews.ts";
@@ -25,6 +31,31 @@ import { matchesGitLab, extractGitLab } from "./gitlab.ts";
 export interface ExtractorMatch {
 	name: string;
 	matcher: (url: string) => boolean;
+}
+
+// ─── User extractor registry ─────────────────────────────────────────
+// Populated once at startup by calling initUserExtractors().
+// User extractors are checked BEFORE built-ins so users can override
+// built-in behavior for a given URL pattern.
+let _userExtractors: RegisteredUserExtractor[] = [];
+
+/**
+ * Load user extractors from the config directory and register them.
+ * Should be called once at extension startup. Safe to call multiple times;
+ * subsequent calls replace the previous set.
+ *
+ * @param dirPath Optional override for the config directory path (for tests).
+ */
+export async function initUserExtractors(dirPath?: string): Promise<void> {
+	_userExtractors = await loadUserExtractors(dirPath);
+}
+
+/**
+ * Returns a copy of the currently registered user extractors.
+ * Primarily useful for tests and diagnostics.
+ */
+export function getUserExtractors(): RegisteredUserExtractor[] {
+	return [..._userExtractors];
 }
 
 export const VERTICAL_EXTRACTORS: ExtractorMatch[] = [
@@ -51,8 +82,16 @@ export const VERTICAL_EXTRACTORS: ExtractorMatch[] = [
 
 /**
  * Find which vertical extractor matches a URL.
+ * User extractors are checked before built-ins.
  */
 export function findVerticalExtractor(url: string): string | null {
+	for (const u of _userExtractors) {
+		try {
+			if (u.match(url)) return u.name;
+		} catch {
+			// ignore matcher errors during attribution lookup
+		}
+	}
 	for (const v of VERTICAL_EXTRACTORS) {
 		if (v.matcher(url)) return v.name;
 	}
@@ -61,6 +100,9 @@ export function findVerticalExtractor(url: string): string | null {
 
 /**
  * Run the appropriate vertical extractor for a URL.
+ * User extractors are checked before built-ins.
+ * Runtime errors from user extractors are caught and logged; the function
+ * then falls through to the built-in pipeline rather than crashing.
  * Returns null if no extractor matches or extraction fails.
  */
 export async function runVerticalExtractor(
@@ -69,6 +111,30 @@ export async function runVerticalExtractor(
 	fetchText: (url: string) => Promise<string | null>,
 	fetchHtml: (url: string) => Promise<string | null>,
 ): Promise<VerticalResult | null> {
+	// User extractors take priority — checked before any built-in
+	for (const u of _userExtractors) {
+		let matches = false;
+		try {
+			matches = u.match(url);
+		} catch (err) {
+			console.warn(
+				`[user-verticals] ${u.name} (${u.filePath}) match() threw: ${(err as Error).message}`,
+			);
+			continue;
+		}
+		if (!matches) continue;
+
+		try {
+			const result = await u.extract(url, fetchJson, fetchText, fetchHtml);
+			if (result !== null) return result;
+		} catch (err) {
+			console.warn(
+				`[user-verticals] ${u.name} (${u.filePath}) extract() threw for ${url}: ${(err as Error).message} — falling through to built-in pipeline`,
+			);
+			// Fall through: do not return, continue to built-ins below
+		}
+	}
+
 	if (matchesNpm(url)) {
 		return extractNpm(url, fetchJson);
 	}

--- a/src/verticals/user-loader.ts
+++ b/src/verticals/user-loader.ts
@@ -1,0 +1,149 @@
+// ─── User-defined vertical extractor loader ─────────────────────────
+// Loads .mjs modules from ~/.pi/agent/webaio/verticals/ at startup.
+// Each module must default-export (or named-export `extractor`) an object
+// conforming to UserExtractorModule. Invalid modules are skipped with a
+// warning; a missing directory is silently ignored.
+//
+// SECURITY: Files in the config directory are executed as arbitrary ESM
+// with the full privileges of the pi-webaio agent process. Only place
+// modules there that you trust completely.
+
+import { readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { VerticalResult } from "./types.ts";
+
+// ─── Public contract ────────────────────────────────────────────────
+
+export interface UserExtractorModule {
+	/** A short identifier shown in the "via <name>" attribution line. */
+	name: string;
+	/** Returns true when this extractor should handle the given URL. */
+	match: (url: string) => boolean;
+	/**
+	 * Perform the extraction.  Receives lightweight fetch helpers so the
+	 * module doesn't need to import anything from the host package.
+	 */
+	extract: (
+		url: string,
+		fetchJson: (url: string) => Promise<unknown | null>,
+		fetchText: (url: string) => Promise<string | null>,
+		fetchHtml: (url: string) => Promise<string | null>,
+	) => Promise<VerticalResult | null>;
+}
+
+export interface RegisteredUserExtractor {
+	name: string;
+	filePath: string;
+	match: (url: string) => boolean;
+	extract: UserExtractorModule["extract"];
+}
+
+// ─── Validation ──────────────────────────────────────────────────────
+
+function validate(
+	mod: unknown,
+	filePath: string,
+): UserExtractorModule | string {
+	if (!mod || typeof mod !== "object") {
+		return "default export is not an object";
+	}
+	const m = mod as Record<string, unknown>;
+
+	if (typeof m.name !== "string" || m.name.trim() === "") {
+		return 'missing or empty string field "name"';
+	}
+	if (typeof m.match !== "function") {
+		return 'missing or non-function field "match"';
+	}
+	if (typeof m.extract !== "function") {
+		return 'missing or non-function field "extract"';
+	}
+
+	// Smoke-test: match() must not throw on a plain URL string
+	try {
+		m.match("https://example.com/");
+	} catch (err) {
+		return `match() threw on a test URL: ${(err as Error).message}`;
+	}
+
+	return m as unknown as UserExtractorModule;
+}
+
+// ─── Loader ──────────────────────────────────────────────────────────
+
+/**
+ * Default config directory: ~/.pi/agent/webaio/verticals/
+ * Override by passing a dirPath or setting PI_WEBAIO_USER_VERTICALS_DIR
+ * (useful for tests).
+ */
+export function resolveUserVerticalsDir(override?: string): string {
+	if (override) return resolve(override);
+	if (process.env.PI_WEBAIO_USER_VERTICALS_DIR) {
+		return resolve(process.env.PI_WEBAIO_USER_VERTICALS_DIR);
+	}
+	return join(homedir(), ".pi", "agent", "webaio", "verticals");
+}
+
+/**
+ * Load all .mjs user extractor modules from the given directory.
+ * Returns an array of validated extractors ready for registration.
+ * Never throws — all errors are logged as warnings.
+ */
+export async function loadUserExtractors(
+	dirPath?: string,
+): Promise<RegisteredUserExtractor[]> {
+	const dir = resolveUserVerticalsDir(dirPath);
+	let entries: string[];
+
+	try {
+		entries = await readdir(dir);
+	} catch (err: unknown) {
+		// Missing directory is the common case — skip silently
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+		// Any other FS error (permission, etc.) — warn and continue
+		console.warn(
+			`[user-verticals] Cannot read directory ${dir}: ${(err as Error).message}`,
+		);
+		return [];
+	}
+
+	const mjsFiles = entries
+		.filter((f) => f.endsWith(".mjs"))
+		.map((f) => join(dir, f));
+
+	const loaded: RegisteredUserExtractor[] = [];
+
+	for (const filePath of mjsFiles) {
+		let rawMod: unknown;
+		try {
+			rawMod = await import(pathToFileURL(filePath).href);
+		} catch (err) {
+			console.warn(
+				`[user-verticals] Failed to import ${filePath}: ${(err as Error).message}`,
+			);
+			continue;
+		}
+
+		// Support both default export and named `extractor` export
+		const candidate =
+			(rawMod as Record<string, unknown>).default ??
+			(rawMod as Record<string, unknown>).extractor;
+
+		const result = validate(candidate, filePath);
+		if (typeof result === "string") {
+			console.warn(`[user-verticals] Skipping ${filePath}: ${result}`);
+			continue;
+		}
+
+		loaded.push({
+			name: result.name,
+			filePath,
+			match: result.match,
+			extract: result.extract,
+		});
+	}
+
+	return loaded;
+}

--- a/tests/user-verticals.test.mjs
+++ b/tests/user-verticals.test.mjs
@@ -1,0 +1,237 @@
+/**
+ * Tests for user-defined vertical extractor loading (issue #49).
+ *
+ * The loader is pointed at a temp fixture directory for each test.
+ * The PI_WEBAIO_USER_VERTICALS_DIR env var is used to inject the
+ * directory path into the registry, but we also call initUserExtractors()
+ * with an explicit path argument to keep tests isolated.
+ */
+
+import assert from "node:assert";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	loadUserExtractors,
+} from "../src/verticals/user-loader.ts";
+
+import {
+	initUserExtractors,
+	getUserExtractors,
+	findVerticalExtractor,
+	runVerticalExtractor,
+} from "../src/verticals/registry.ts";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+async function makeTempDir() {
+	return mkdtemp(join(tmpdir(), "pi-webaio-test-verticals-"));
+}
+
+async function writeMjs(dir, filename, content) {
+	const p = join(dir, filename);
+	await writeFile(p, content, "utf8");
+	return p;
+}
+
+/** Stub fetch helpers that always return null */
+const noFetch = async () => null;
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+test("missing directory is a no-op", async () => {
+	const result = await loadUserExtractors("/nonexistent/path/that/does/not/exist");
+	assert.deepStrictEqual(result, []);
+});
+
+test("valid module loads and registers", async (t) => {
+	const dir = await makeTempDir();
+	t.after(() => rm(dir, { recursive: true, force: true }));
+
+	await writeMjs(dir, "example.mjs", `
+export default {
+  name: "example",
+  match(url) { return url.includes("example-site.internal"); },
+  async extract(url) {
+    return { ok: true, url, title: "Example", content: "# Example\\n\\nHello." };
+  },
+};
+`);
+
+	const loaded = await loadUserExtractors(dir);
+	assert.strictEqual(loaded.length, 1);
+	assert.strictEqual(loaded[0].name, "example");
+	assert.strictEqual(typeof loaded[0].match, "function");
+	assert.strictEqual(typeof loaded[0].extract, "function");
+});
+
+test("invalid module skipped with warning", async (t) => {
+	const dir = await makeTempDir();
+	t.after(() => rm(dir, { recursive: true, force: true }));
+
+	// Missing `name` field
+	await writeMjs(dir, "bad.mjs", `
+export default {
+  match(url) { return true; },
+  async extract(url) { return null; },
+};
+`);
+
+	const warnings = [];
+	const origWarn = console.warn;
+	console.warn = (...args) => warnings.push(args.join(" "));
+
+	const loaded = await loadUserExtractors(dir);
+
+	console.warn = origWarn;
+
+	assert.strictEqual(loaded.length, 0);
+	assert.ok(
+		warnings.some((w) => w.includes("bad.mjs")),
+		"Expected a warning mentioning bad.mjs",
+	);
+});
+
+test("module with syntax error is skipped with warning", async (t) => {
+	const dir = await makeTempDir();
+	t.after(() => rm(dir, { recursive: true, force: true }));
+
+	await writeMjs(dir, "broken.mjs", `this is not valid javascript @@@@`);
+
+	const warnings = [];
+	const origWarn = console.warn;
+	console.warn = (...args) => warnings.push(args.join(" "));
+
+	const loaded = await loadUserExtractors(dir);
+
+	console.warn = origWarn;
+
+	assert.strictEqual(loaded.length, 0);
+	assert.ok(
+		warnings.some((w) => w.includes("broken.mjs")),
+		"Expected a warning mentioning broken.mjs",
+	);
+});
+
+test("named export `extractor` is also accepted", async (t) => {
+	const dir = await makeTempDir();
+	t.after(() => rm(dir, { recursive: true, force: true }));
+
+	await writeMjs(dir, "named.mjs", `
+export const extractor = {
+  name: "named-export",
+  match(url) { return url.includes("named-export.example"); },
+  async extract(url) {
+    return { ok: true, url, title: "Named", content: "named" };
+  },
+};
+`);
+
+	const loaded = await loadUserExtractors(dir);
+	assert.strictEqual(loaded.length, 1);
+	assert.strictEqual(loaded[0].name, "named-export");
+});
+
+test("user extractor takes precedence over built-ins", async (t) => {
+	const dir = await makeTempDir();
+	t.after(async () => {
+		rm(dir, { recursive: true, force: true });
+		// reset registry state
+		await initUserExtractors("/nonexistent/path/$$reset$$");
+	});
+
+	// Override the PyPI built-in for test purposes
+	await writeMjs(dir, "mypypi.mjs", `
+export default {
+  name: "my-pypi-override",
+  match(url) { return url.startsWith("https://pypi.org/"); },
+  async extract(url) {
+    return { ok: true, url, title: "Override", content: "overridden" };
+  },
+};
+`);
+
+	await initUserExtractors(dir);
+
+	// findVerticalExtractor should return the user extractor name
+	const name = findVerticalExtractor("https://pypi.org/project/requests");
+	assert.strictEqual(name, "my-pypi-override");
+
+	// runVerticalExtractor should return the user extractor result
+	const result = await runVerticalExtractor(
+		"https://pypi.org/project/requests",
+		noFetch,
+		noFetch,
+		noFetch,
+	);
+	assert.ok(result);
+	assert.strictEqual(result.ok, true);
+	assert.strictEqual(result.content, "overridden");
+});
+
+test("runtime error in user extractor falls through to built-in pipeline", async (t) => {
+	const dir = await makeTempDir();
+	t.after(async () => {
+		rm(dir, { recursive: true, force: true });
+		await initUserExtractors("/nonexistent/path/$$reset$$");
+	});
+
+	await writeMjs(dir, "erroring.mjs", `
+export default {
+  name: "erroring",
+  match(url) { return url.includes("hackernews-special.test"); },
+  async extract(url) { throw new Error("intentional test error"); },
+};
+`);
+
+	await initUserExtractors(dir);
+
+	const warnings = [];
+	const origWarn = console.warn;
+	console.warn = (...args) => warnings.push(args.join(" "));
+
+	// The URL doesn't match any built-in extractor, so we should get null (not a throw)
+	let threw = false;
+	let result = null;
+	try {
+		result = await runVerticalExtractor(
+			"https://hackernews-special.test/item?id=1",
+			noFetch,
+			noFetch,
+			noFetch,
+		);
+	} catch {
+		threw = true;
+	}
+
+	console.warn = origWarn;
+
+	assert.strictEqual(threw, false, "runVerticalExtractor must not throw");
+	assert.strictEqual(result, null, "should return null when all extractors fail/miss");
+	assert.ok(
+		warnings.some((w) => w.includes("intentional test error")),
+		"Expected warning about the error",
+	);
+});
+
+test("multiple valid modules all load", async (t) => {
+	const dir = await makeTempDir();
+	t.after(() => rm(dir, { recursive: true, force: true }));
+
+	for (const name of ["alpha", "beta", "gamma"]) {
+		await writeMjs(dir, `${name}.mjs`, `
+export default {
+  name: "${name}",
+  match(url) { return url.includes("${name}.example"); },
+  async extract(url) { return { ok: true, url, content: "${name}" }; },
+};
+`);
+	}
+
+	const loaded = await loadUserExtractors(dir);
+	assert.strictEqual(loaded.length, 3);
+	const names = loaded.map((e) => e.name).sort();
+	assert.deepStrictEqual(names, ["alpha", "beta", "gamma"]);
+});


### PR DESCRIPTION
Closes #49.

Loads user extractor modules from `~/.pi/agent/webaio/verticals/*.mjs` at startup, so users can add site-specific extractors (company wikis, niche sites) without forking.

- New `src/verticals/user-loader.ts`: dynamic import, contract validation (name/match/extract), invalid modules skipped with a clear per-file warning — never crashes startup; missing dir is a silent no-op
- User extractors are consulted before built-ins, so they can override built-in behavior
- Runtime `extract()` errors are caught and fall through to the normal pipeline
- Config dir injectable via arg or `PI_WEBAIO_USER_VERTICALS_DIR` (used by tests; no home-dir touching)
- `docs/custom-verticals.md`: full contract, copy-paste example, and an explicit security notice that config-dir modules execute arbitrary code
- 8 new tests; full suite and tsc pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)