### PR TITLE
websearch: preferred-domain inference boost in ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to pi-webaio will be documented in this file.
 
 ### Added
 
+- **Preferred-domain ranking boost** (`src/search.ts`) — `inferPreferredDomains` maps ~35 query keywords (framework/tool/vendor names) to canonical official domains (e.g. "prisma" → `prisma.io`, "anthropic"/"claude" → `anthropic.com`, `docs.anthropic.com`); `scoreAndRankResults` now boosts results whose host matches an inferred domain for the query, so official docs outrank generic SEO results with equal engine consensus ([#63](https://github.com/apmantza/pi-webaio/issues/63)).
+
 ### Changed
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "test:prune": "node --experimental-strip-types --test tests/prune-markdown.test.mjs",
     "test:github-map": "node --experimental-strip-types --test tests/github-map.test.mjs",
     "test:reddit": "node --experimental-strip-types --test tests/reddit-block.test.mjs",
-    "test:all": "node --experimental-strip-types --test tests/unit.test.mjs tests/new-features.test.mjs tests/paywall.test.mjs tests/github-check.test.mjs tests/reddit-block.test.mjs tests/github-map.test.mjs tests/render-result.test.mjs tests/fetch-error.test.mjs tests/fetch-progress.test.mjs tests/hardening.test.mjs tests/fingerprint.test.mjs tests/format.test.mjs tests/webfetch-summary.test.mjs tests/chunker.test.mjs tests/prune-markdown.test.mjs tests/integration.test.mjs tests/bench-harness.test.mjs",
+    "test:all": "node --experimental-strip-types --test tests/unit.test.mjs tests/new-features.test.mjs tests/paywall.test.mjs tests/github-check.test.mjs tests/reddit-block.test.mjs tests/github-map.test.mjs tests/render-result.test.mjs tests/fetch-error.test.mjs tests/fetch-progress.test.mjs tests/hardening.test.mjs tests/fingerprint.test.mjs tests/format.test.mjs tests/webfetch-summary.test.mjs tests/chunker.test.mjs tests/prune-markdown.test.mjs tests/integration.test.mjs tests/bench-harness.test.mjs tests/preferred-domain.test.mjs",
     "check:lockfile": "node scripts/check-lockfile-sync.mjs",
     "changelog:check": "node scripts/changelog-release.mjs --check",
     "changelog:release": "node scripts/changelog-release.mjs",

--- a/src/search.ts
+++ b/src/search.ts
@@ -338,16 +338,108 @@ export const ENGINE_WEIGHTS: Record<string, number> = {
 	yahoo: 1,
 };
 
+// Query keyword → canonical official domain(s). Crude but free: when a query
+// clearly targets a known tool/framework/vendor, results hosted on its
+// official domain get a ranking boost over generic (e.g. SEO blogspam)
+// results with equal engine consensus.
+// Ported from greedysearch-pi's `inferPreferredDomains` (src/search/sources.mjs).
+const PREFERRED_DOMAIN_RULES: {
+	keywords: string[];
+	domains: string[];
+	test?: RegExp;
+}[] = [
+	{ keywords: ["openai", "gpt", "chatgpt"], domains: ["openai.com", "platform.openai.com", "help.openai.com"] },
+	{ keywords: ["anthropic", "claude"], domains: ["anthropic.com", "docs.anthropic.com"] },
+	{ keywords: ["bun"], domains: ["bun.sh", "bun.com"] },
+	{ keywords: ["next.js", "nextjs"], domains: ["nextjs.org", "vercel.com"] },
+	{ keywords: ["playwright"], domains: ["playwright.dev"] },
+	{ keywords: ["supabase"], domains: ["supabase.com", "supabase.io"] },
+	{ keywords: ["prisma"], domains: ["prisma.io"] },
+	{ keywords: ["tailwind"], domains: ["tailwindcss.com"] },
+	{ keywords: ["vite"], domains: ["vitejs.dev", "vite.dev"] },
+	{ keywords: ["astro"], domains: ["astro.build"] },
+	{ keywords: ["svelte"], domains: ["svelte.dev"] },
+	{ keywords: ["solid"], domains: ["solidjs.com"] },
+	{ keywords: ["vue", "nuxt"], domains: ["vuejs.org", "nuxt.com"] },
+	{ keywords: ["react", "react native"], domains: ["react.dev", "reactnative.dev"] },
+	{ keywords: ["angular"], domains: ["angular.io", "angular.dev"] },
+	{ keywords: ["node.js", "nodejs"], domains: ["nodejs.org", "nodejs.dev", "npmjs.com"] },
+	{ keywords: ["golang"], domains: ["go.dev", "golang.org", "pkg.go.dev"], test: /\bgo\b/ },
+	{ keywords: ["deno"], domains: ["deno.land", "deno.com"] },
+	{ keywords: ["fresh"], domains: ["fresh.deno.dev"] },
+	{ keywords: ["typescript"], domains: ["typescriptlang.org"] },
+	{ keywords: ["python"], domains: ["python.org", "docs.python.org"] },
+	{ keywords: ["rust"], domains: ["rust-lang.org", "docs.rs", "crates.io"] },
+	{ keywords: ["zig"], domains: ["ziglang.org"] },
+	{ keywords: ["docker"], domains: ["docker.com", "docs.docker.com", "hub.docker.com"] },
+	{ keywords: ["kubernetes", "k8s"], domains: ["kubernetes.io", "k8s.io"] },
+	{ keywords: ["postgres", "postgresql"], domains: ["postgresql.org", "neon.tech", "supabase.com"] },
+	{ keywords: ["redis"], domains: ["redis.io"] },
+	{ keywords: ["sqlite"], domains: ["sqlite.org"] },
+	{ keywords: ["cloudflare"], domains: ["developers.cloudflare.com", "cloudflare.com"] },
+	{ keywords: ["vercel"], domains: ["vercel.com", "nextjs.org"] },
+	{ keywords: ["netlify"], domains: ["netlify.com", "docs.netlify.com"] },
+	{ keywords: ["stripe"], domains: ["stripe.com", "docs.stripe.com"] },
+	{ keywords: ["github"], domains: ["github.com", "docs.github.com"] },
+	{ keywords: ["gitlab"], domains: ["gitlab.com", "docs.gitlab.com"] },
+	{ keywords: ["aws"], domains: ["aws.amazon.com", "docs.aws.amazon.com"] },
+	{ keywords: ["azure"], domains: ["azure.microsoft.com", "learn.microsoft.com"] },
+	{ keywords: ["gcp", "google cloud"], domains: ["cloud.google.com", "developers.google.com"] },
+	{ keywords: ["gemini", "google ai"], domains: ["ai.google.dev", "developers.google.com"] },
+];
+
+/**
+ * Infer canonical official domains implied by a search query's keywords
+ * (e.g. "prisma migrate guide" → ["prisma.io"]). Returns an empty array
+ * when nothing matches — callers should treat that as "no boost".
+ */
+export function inferPreferredDomains(query: string): string[] {
+	const normalized = query.toLowerCase();
+	const matches: string[] = [];
+
+	for (const rule of PREFERRED_DOMAIN_RULES) {
+		const matched =
+			rule.keywords.some((kw) => normalized.includes(kw)) ||
+			(rule.test?.test(normalized) ?? false);
+		if (matched) matches.push(...rule.domains);
+	}
+
+	return [...new Set(matches)];
+}
+
+function hostMatchesDomain(hostname: string, domain: string): boolean {
+	return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+// Boost applied when a result's host matches a query-inferred preferred
+// domain. Chosen to be additive/small so it composes cleanly with the
+// existing engine-weight + consensus scoring instead of overriding it.
+export const PREFERRED_DOMAIN_BOOST = 4;
+
 export function scoreAndRankResults(
 	buckets: Map<string, EngineSource[]>,
+	query = "",
 ): { result: SearchResult; score: number; sources: string[] }[] {
+	const preferredDomains = inferPreferredDomains(query);
 	const scored: { result: SearchResult; score: number; sources: string[] }[] =
 		[];
 	for (const [url, entries] of buckets) {
 		const sources = entries.map((e) => e.engine);
 		const weightSum = entries.reduce((sum, e) => sum + e.weight, 0);
 		const consensusBonus = Math.max(0, sources.length - 1) * 2;
-		const score = weightSum + consensusBonus;
+
+		let domainBoost = 0;
+		if (preferredDomains.length > 0) {
+			const hostname = extractDomain(url)?.replace(/^www\./, "") || "";
+			if (
+				hostname &&
+				preferredDomains.some((d) => hostMatchesDomain(hostname, d))
+			) {
+				domainBoost = PREFERRED_DOMAIN_BOOST;
+			}
+		}
+
+		const score = weightSum + consensusBonus + domainBoost;
 
 		entries.sort((a, b) => b.weight - a.weight);
 		const best = entries[0]!.result;
@@ -488,7 +580,7 @@ export async function searchWeb(query: string): Promise<{
 		}
 	}
 
-	const scored = scoreAndRankResults(engineResults);
+	const scored = scoreAndRankResults(engineResults, query);
 	const merged = scored.map((s) => s.result);
 
 	if (merged.length > 0) {

--- a/src/tools/websearch.ts
+++ b/src/tools/websearch.ts
@@ -191,7 +191,7 @@ export function registerWebsearchTool(pi: ExtensionAPI): void {
 				buckets.set(r.url, list);
 			}
 
-			const scored = scoreAndRankResults(buckets);
+			const scored = scoreAndRankResults(buckets, query);
 			const merged = scored.map((s) => s.result);
 
 			if (!merged.length) {

--- a/tests/preferred-domain.test.mjs
+++ b/tests/preferred-domain.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert";
+import test from "node:test";
+import {
+	inferPreferredDomains,
+	scoreAndRankResults,
+} from "../src/search.ts";
+
+test("inferPreferredDomains: matches known keywords to canonical domains", () => {
+	assert.deepStrictEqual(inferPreferredDomains("prisma migrate guide"), [
+		"prisma.io",
+	]);
+	assert.deepStrictEqual(inferPreferredDomains("vite config"), [
+		"vitejs.dev",
+		"vite.dev",
+	]);
+	assert.deepStrictEqual(
+		inferPreferredDomains("anthropic claude api docs"),
+		["anthropic.com", "docs.anthropic.com"],
+	);
+});
+
+test("inferPreferredDomains: matches bare 'go' via word boundary, not substrings", () => {
+	const domains = inferPreferredDomains("go error handling");
+	assert.deepStrictEqual(domains, ["go.dev", "golang.org", "pkg.go.dev"]);
+
+	// "google" contains "go" but must not trigger the golang rule.
+	const googleDomains = inferPreferredDomains("google search tips");
+	assert.ok(!googleDomains.includes("go.dev"));
+});
+
+test("inferPreferredDomains: returns empty array when nothing matches", () => {
+	assert.deepStrictEqual(inferPreferredDomains("how to bake bread"), []);
+});
+
+test("inferPreferredDomains: dedupes domains contributed by multiple rules", () => {
+	const domains = inferPreferredDomains("postgres vs supabase");
+	const seen = new Set(domains);
+	assert.strictEqual(domains.length, seen.size);
+	assert.ok(domains.includes("supabase.com"));
+});
+
+test("scoreAndRankResults: a matched official domain outranks an unmatched result with equal engine consensus", () => {
+	const buckets = new Map([
+		[
+			"https://prisma.io/docs/guide",
+			[
+				{
+					result: {
+						title: "Prisma Guide",
+						url: "https://prisma.io/docs/guide",
+						snippet: "Official Prisma docs.",
+					},
+					engine: "ddg",
+					weight: 2,
+				},
+			],
+		],
+		[
+			"https://some-blog.example.com/prisma-tutorial",
+			[
+				{
+					result: {
+						title: "Prisma Tutorial",
+						url: "https://some-blog.example.com/prisma-tutorial",
+						snippet: "A blog post about Prisma.",
+					},
+					engine: "ddg",
+					weight: 2,
+				},
+			],
+		],
+	]);
+
+	const scored = scoreAndRankResults(buckets, "prisma migrate tutorial");
+
+	assert.strictEqual(scored[0].result.url, "https://prisma.io/docs/guide");
+	assert.ok(
+		scored[0].score > scored[1].score,
+		"official domain result should score higher than the unmatched result",
+	);
+});
+
+test("scoreAndRankResults: no boost applied when query has no preferred domain", () => {
+	const buckets = new Map([
+		[
+			"https://prisma.io/docs/guide",
+			[
+				{
+					result: {
+						title: "Prisma Guide",
+						url: "https://prisma.io/docs/guide",
+						snippet: "Official Prisma docs.",
+					},
+					engine: "ddg",
+					weight: 2,
+				},
+			],
+		],
+		[
+			"https://some-blog.example.com/random",
+			[
+				{
+					result: {
+						title: "Random Post",
+						url: "https://some-blog.example.com/random",
+						snippet: "Unrelated content.",
+					},
+					engine: "ddg",
+					weight: 2,
+				},
+			],
+		],
+	]);
+
+	const scored = scoreAndRankResults(buckets, "how to bake bread");
+	assert.strictEqual(scored[0].score, scored[1].score);
+});


### PR DESCRIPTION
## Summary

- Adds `inferPreferredDomains(query)` to `src/search.ts` — a small hardcoded map from ~35 query keywords (framework/tool/vendor names) to canonical official domains (e.g. "prisma" → `prisma.io`, "vite" → `vitejs.dev`/`vite.dev`, "anthropic"/"claude" → `anthropic.com`/`docs.anthropic.com`), ported and extended from greedysearch-pi's `inferPreferredDomains` (`src/search/sources.mjs`, MIT, same author).
- `scoreAndRankResults` now accepts the query and adds a small additive boost (`PREFERRED_DOMAIN_BOOST = 4`) to results whose host matches an inferred domain, so official docs outrank generic/SEO results with equal engine consensus. The query is threaded through from both callers: `searchWeb` in `src/search.ts` and the `aio-websearch` tool in `src/tools/websearch.ts`.
- Unit tests in `tests/preferred-domain.test.mjs`: keyword→domain mapping lookups (including a word-boundary check so "google" doesn't false-positive the bare "go" → golang rule), empty-match and dedupe cases, and a ranking assertion that a matched official domain outranks an unmatched result with equal engine consensus. Added to the `test:all` script so CI exercises it.
- Added a CHANGELOG `[Unreleased]` bullet. No version bump.

**Note:** This touches the same function (`scoreAndRankResults` in `src/search.ts:341`) as #61 (source-type classification, on `feat/source-type-ranking`). This PR intentionally keeps its change small and purely additive (a `domainBoost` term added to the existing score) to minimize conflict — it does not implement #61's classifier. Whichever of the two lands second will likely need a trivial rebase to merge the two boost terms into the same `score` expression.

## Test plan

- [x] `npm run lint` (tsc typecheck) — passes
- [x] `npm run build` (tsc dist build) — passes
- [x] `npm test` (unit suite) — 149/149 pass
- [x] `npm run test:all` (full suite incl. new `tests/preferred-domain.test.mjs`) — 591/592 pass, 1 pre-existing skip, 0 fail

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)