### PR TITLE
fix: stop vendoring host-provided typebox and pi-tui (closes #108)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,11 @@ jobs:
       # PRs on fix-less moderate advisories; transitive moderate ones are
       # handled by Dependabot security updates. DevDeps are excluded — they
       # never reach users.
-      # Peer deps are excluded as well: the only peer (pi-coding-agent) is
-      # host-provided, and npm overrides do NOT cascade into a peer's subtree,
-      # so its transitive brace-expansion@5.0.7 advisory (GHSA-mh99-v99m-4gvg)
-      # cannot be bumped from this repo — it is upstream's responsibility.
+      # Peer deps are excluded as well: both peers (pi-coding-agent, pi-tui;
+      # #108) are host-provided, and npm overrides do NOT cascade into a
+      # peer's subtree, so pi-coding-agent's transitive brace-expansion@5.0.7
+      # advisory (GHSA-mh99-v99m-4gvg) cannot be bumped from this repo — it is
+      # upstream's responsibility.
       - name: Audit production dependencies
         run: npm audit --omit=dev --omit=peer --audit-level=high
 
@@ -124,10 +125,10 @@ jobs:
               "(TS2688? prepare/build:dist failed)" && exit 1)
           node dist/index.js 2>&1 | tee /tmp/load.txt || true
           # ERR_MODULE_NOT_FOUND = a runtime dep was wrongly in devDependencies.
-          # pi-coding-agent is a host-provided peer; its absence is expected
-          # here.
+          # pi-coding-agent and pi-tui (#108) are host-provided peers; their
+          # absence is expected here.
           if grep -q "ERR_MODULE_NOT_FOUND\|Cannot find module" /tmp/load.txt \
-             && ! grep -q "pi-coding-agent" /tmp/load.txt; then
+             && ! grep -Eq "pi-coding-agent|pi-tui" /tmp/load.txt; then
             echo "FAILED: missing runtime module under --omit=dev"
             cat /tmp/load.txt
             exit 1
@@ -245,14 +246,14 @@ jobs:
           # loaded by node.
           # ERR_MODULE_NOT_FOUND = missing dep -> fail
           # Any other error = expected in CI (no pi API available) -> pass
-          # pi-coding-agent is a host-provided peer dep; its absence is
-          # expected here
+          # pi-coding-agent and pi-tui (#108) are host-provided peer deps;
+          # their absence is expected here
           ENTRY=$(node -p "require('./package.json').pi.extensions[0]")
           echo "Loading entry: $ENTRY"
           node "$ENTRY" 2>&1 | tee /tmp/load-output.txt || true
           if grep -q "ERR_MODULE_NOT_FOUND\|Cannot find module" \
              /tmp/load-output.txt \
-             && ! grep -q "pi-coding-agent" /tmp/load-output.txt; then
+             && ! grep -Eq "pi-coding-agent|pi-tui" /tmp/load-output.txt; then
             echo "FAILED: missing module dependency detected"
             cat /tmp/load-output.txt
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to pi-webaio will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **Stopped vendoring host-provided `typebox` and `@earendil-works/pi-tui`** (#108, same shape as pi-lens#1928) — `typebox` was a declared runtime dependency but nothing in `src/` imports it; pi's own `@earendil-works/pi-coding-agent` subtree already carries the copy it needs, so the top-level one was pure dead weight and is now removed outright. `@earendil-works/pi-tui` is genuinely used (lazily, in `src/tools/websearch.ts` and `src/tools/render-result.ts`, loaded only when a tool first runs), so it moves to an optional peer dependency plus a devDependency instead — pi resolves the bare specifier from its own runtime, the same way it already does for the `@earendil-works/pi-coding-agent` peer. A production install (`npm install --omit=dev`) no longer vendors either package.
+
 ## [0.9.0] - 2026-08-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to pi-webaio will be documented in this file.
 
 ### Fixed
 
-- **Stopped vendoring host-provided `typebox` and `@earendil-works/pi-tui`** (#108, same shape as pi-lens#1928) — `typebox` was a declared runtime dependency but nothing in `src/` imports it; pi's own `@earendil-works/pi-coding-agent` subtree already carries the copy it needs, so the top-level one was pure dead weight and is now removed outright. `@earendil-works/pi-tui` is genuinely used (lazily, in `src/tools/websearch.ts` and `src/tools/render-result.ts`, loaded only when a tool first runs), so it moves to an optional peer dependency plus a devDependency instead — pi resolves the bare specifier from its own runtime, the same way it already does for the `@earendil-works/pi-coding-agent` peer. A production install (`npm install --omit=dev`) no longer vendors either package.
+- **Stopped vendoring host-provided `typebox` and `@earendil-works/pi-tui`** (#108, same shape as pi-lens#1928). `typebox` is removed outright: nothing in `src/` imports it, and pi's own `@earendil-works/pi-coding-agent` subtree already carries the copy it needs. `@earendil-works/pi-tui` is genuinely used, lazily, in `src/tools/websearch.ts` and `src/tools/render-result.ts`. It moves to an optional peer dependency plus a devDependency, and pi resolves the bare specifier from its own runtime, as it already does for the `@earendil-works/pi-coding-agent` peer. A production install (`npm install --omit=dev`) no longer vendors either package.
 
 ## [0.9.0] - 2026-08-17
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,11 @@
       "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-tui": "^0.83.0 || ^0.84.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@mozilla/readability": "^0.6.0",
         "defuddle": "^0.19.2",
         "linkedom": "^0.18.12",
         "pdf-parse": "^2.4.5",
-        "typebox": "^1.1.34",
         "wreq-js": "^3.0.0",
         "ws": "^8.21.1",
         "youtube-transcript-plus": "^2.0.0"
@@ -24,6 +22,7 @@
         "pi-webaio-mcp": "bin/pi-webaio-mcp.mjs"
       },
       "devDependencies": {
+        "@earendil-works/pi-tui": "^0.83.0 || ^0.84.0",
         "@types/node": "^26.1.2",
         "@types/ws": "^8.18.1",
         "typescript": "^7.0.2"
@@ -32,7 +31,13 @@
         "playwright": "^1.55.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.83.0 || ^0.84.0"
+        "@earendil-works/pi-coding-agent": "^0.83.0 || ^0.84.0",
+        "@earendil-works/pi-tui": "^0.83.0 || ^0.84.0"
+      },
+      "peerDependenciesMeta": {
+        "@earendil-works/pi-tui": {
+          "optional": true
+        }
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
@@ -2046,6 +2051,7 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
       "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -3313,6 +3319,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3628,6 +3635,7 @@
       "version": "18.0.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
       "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -4183,12 +4191,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/typebox": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.13.tgz",
-      "integrity": "sha512-rzv/3uBDgWGb5b4+Rqb/WoDFCc+5N0iRC/7kgQyk/mJJeumQjHFFAZ+X+Zs+CNxnNnJOkhIMrQc2irTzfEbKjw==",
-      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -122,18 +122,22 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "@earendil-works/pi-tui": "^0.83.0 || ^0.84.0",
     "@mozilla/readability": "^0.6.0",
     "defuddle": "^0.19.2",
     "linkedom": "^0.18.12",
     "pdf-parse": "^2.4.5",
-    "typebox": "^1.1.34",
     "wreq-js": "^3.0.0",
     "youtube-transcript-plus": "^2.0.0",
     "ws": "^8.21.1"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.83.0 || ^0.84.0"
+    "@earendil-works/pi-coding-agent": "^0.83.0 || ^0.84.0",
+    "@earendil-works/pi-tui": "^0.83.0 || ^0.84.0"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-tui": {
+      "optional": true
+    }
   },
   "overrides": {
     "protobufjs": "^7.6.5",
@@ -143,6 +147,7 @@
     "playwright": "^1.55.0"
   },
   "devDependencies": {
+    "@earendil-works/pi-tui": "^0.83.0 || ^0.84.0",
     "@types/node": "^26.1.2",
     "typescript": "^7.0.2",
     "@types/ws": "^8.18.1"

--- a/types/pi-tui.d.ts
+++ b/types/pi-tui.d.ts
@@ -1,0 +1,74 @@
+/**
+ * Ambient type declaration for @earendil-works/pi-tui (#108).
+ *
+ * pi-tui is a pi-bundled core package: pi resolves the bare specifier from
+ * its own runtime, so pi-webaio declares it as an OPTIONAL peer plus a
+ * devDependency and never as a runtime dependency (a runtime dependency
+ * would make `npm install --omit=dev` -- the command pi runs for a `git:`
+ * install -- vendor a private second copy).
+ *
+ * `npm install --omit=dev` also omits devDependencies, so the production
+ * build (`scripts/prepare.mjs`, which runs `tsc --project
+ * tsconfig.dist.json` with full type-checking, unlike pi-lens's
+ * `--noCheck` bundle build) cannot see pi-tui's real .d.ts files in that
+ * environment. This ambient declaration is the fallback: it supplies the
+ * subset of the API `src/tools/render-result.ts` and
+ * `src/tools/websearch.ts` use, so `tsc` resolves the module whether or
+ * not the real package is installed. When the real package IS present
+ * (local dev, CI's `Unit tests` / `Lint & type-check` jobs, which install
+ * devDependencies), this is a no-op safety net -- same pattern as
+ * `types/pi-coding-agent.d.ts` for the other host-provided peer.
+ *
+ * Deliberately NOT a module itself (no top-level import/export): a
+ * `declare module "x"` block inside a file that has import/export of its
+ * own only AUGMENTS an already-resolvable module x, so it does nothing
+ * when the real package is absent -- which is exactly the --omit=dev
+ * case this file exists for. As a global script, this block instead
+ * DEFINES the ambient module outright when nothing else resolves it.
+ */
+
+declare module "@earendil-works/pi-tui" {
+	/** Common shape returned by every widget's `render`/`invalidate` pair. */
+	export interface Component {
+		render(width: number): string[];
+		invalidate(): void;
+	}
+
+	export class Text implements Component {
+		constructor(text: string, x?: number, y?: number);
+		setText(text: string): void;
+		render(width: number): string[];
+		invalidate(): void;
+	}
+
+	export class Container implements Component {
+		constructor();
+		addChild(child: Component): void;
+		render(width: number): string[];
+		invalidate(): void;
+	}
+
+	export class Spacer implements Component {
+		constructor(lines?: number);
+		render(width: number): string[];
+		invalidate(): void;
+	}
+
+	export interface MarkdownTheme {
+		[key: string]: unknown;
+	}
+
+	export class Markdown implements Component {
+		constructor(
+			content: string,
+			x?: number,
+			y?: number,
+			theme?: MarkdownTheme,
+		);
+		render(width: number): string[];
+		invalidate(): void;
+	}
+
+	export function truncateToWidth(text: string, width: number): string;
+	export function visibleWidth(text: string): number;
+}


### PR DESCRIPTION
## What

pi-webaio declared two host-provided packages as runtime dependencies:
`typebox` and `@earendil-works/pi-tui`. A `git:` install (`npm install
--omit=dev`) vendored a private copy of each on top of the copy
already inside `@earendil-works/pi-coding-agent`'s own dependency
tree.

## Why

Same defect shape as pi-lens#1928: a runtime dependency on a
host-provided package doubles the module graph a `git:` install
carries, and gives Node a second copy to resolve and evaluate.

The two packages needed different fixes once I checked actual usage:

- **`typebox` is dead weight, not a duplicate.** Nothing in `src/` or
  `tests/` imports it (`grep -rn "typebox" --include=*.ts` outside
  `node_modules` turns up only comments about the JSON-schema shape
  pi's host SDK emits, never an import). It is not needed for types,
  build, or tests either. Removed outright instead of peer-ed.
- **`@earendil-works/pi-tui` is genuinely used**, but only inside two
  tool modules (`src/tools/websearch.ts`, `src/tools/render-result.ts`)
  that `src/tools/lazy.ts` loads via dynamic `import()` on first tool
  execution, not at extension load. Moved to an optional
  `peerDependency` plus a `devDependency`, mirroring the existing
  `@earendil-works/pi-coding-agent` peer already in this package.json.

## A real build break I found and fixed along the way

Moving `pi-tui` off `dependencies` breaks the production build itself,
not just the install shape. `scripts/prepare.mjs` runs `tsc --project
tsconfig.dist.json` with full type-checking (pi-webaio doesn't bundle
with esbuild the way pi-lens does, so it has no `--noCheck` escape
hatch), and that build runs under `npm install --omit=dev` — the exact
command pi uses for a `git:` install. With `pi-tui` no longer
installed in that environment, `tsc` failed with `TS2307: Cannot find
module '@earendil-works/pi-tui'` in both import sites.

Fixed with `types/pi-tui.d.ts`, an ambient module declaration covering
the subset of the pi-tui API those two files use (`Text`, `Container`,
`Markdown`, `Spacer`, `MarkdownTheme`, `Component`), following the
existing `types/pi-coding-agent.d.ts` pattern for the other
host-provided peer. One difference matters: `pi-coding-agent.d.ts` has
a top-level `export {}`, making it a module — so its `declare module
"x"` block only *augments* an already-resolvable module and silently
does nothing when the real package is absent. `pi-tui.d.ts`
deliberately has no top-level import/export, so it's a global script
instead, and `declare module "x"` in that position *defines* the
ambient module outright when nothing else resolves it. (Whether
`pi-coding-agent.d.ts` has the same latent gap is outside this issue's
scope — noted below.)

## Verification

**Latent-cost claim** (issue says ~10ms import, unaffected by the
fix): timed `import('./dist/index.js')` 5x before and after.
- Before: 7.3 / 6.6 / 7.5ms
- After: 8.3 / 11.3 / 7.3 / 11.9 / 9.4ms

Both bands overlap; the spread is measurement noise (shared CI-class
machine, background load), not evaluation of either package. Confirms
the entry never evaluated them, before or after.

**Fresh `--omit=dev` build** (the real regression test — this is what
CI's `prod-install-build` and git-install-sim jobs do): `git archive`
of the branch into a scratch directory, then `npm install --omit=dev`.
Before `types/pi-tui.d.ts`: reproduced the `TS2307` failure exactly as
CI hit it. After: clean install, `dist/index.js` builds, and `node
dist/index.js` loads with no `ERR_MODULE_NOT_FOUND`. Repeated once
more after the final commit to confirm against the actual pushed
tree.

**Production-install simulation**: `npm pack`, then `npm install
--omit=dev` the tarball into a scratch project. Checked
`node_modules/pi-webaio/node_modules` (does not exist — zero nested
deps) and the wider install tree: neither `typebox` nor
`@earendil-works/pi-tui` appear anywhere. Extension entry loads
cleanly.

**Does the extension still load and work under pi?** `render-result.ts`
— the exact module that imports `pi-tui` — already value-imports
`getMarkdownTheme` from `@earendil-works/pi-coding-agent`, an existing
host-provided peer that ships with zero vendored copy in today's
master. That's a live, already-shipping proof that pi resolves a bare
`@earendil-works/*` specifier for this lazily-loaded module without a
local copy on disk. `pi-tui` gets the identical treatment (optional
peer + devDependency), so the same resolution path applies.

**Build + full suite, with devDependencies installed** (so the real
pi-tui `.d.ts` files are ALSO present, checking the ambient
declaration doesn't collide with them): `npm run build`, `npm run
lint`, and `npm run test:all` (1346 tests) all green — 1344 pass, 2
skipped (pre-existing), 0 failed.

**Lockfile**: regenerated via `npm install`; `npm run check:lockfile`
passes.

## Class sweep

Checked whether any other root runtime dependency is also vendored
inside `@earendil-works/pi-coding-agent`'s own subtree (the same
double-vendor shape). One hit: `ws`. Ruled it out — `ws` is a
general-purpose third-party library, not one of pi's own
`@earendil-works/*` packages that pi deliberately bundles and exposes
to extensions. There's no established contract that pi resolves a
bare `ws` specifier for extensions (unlike `typebox` and `pi-tui`,
both named as host-provided in the pi-lens#1928 precedent). Vendoring
your own `ws` copy is ordinary, expected dependency management, not
this defect class.

Also checked whether `types/pi-coding-agent.d.ts` has the same
module-vs-global-script gap I fixed in `pi-tui.d.ts`. It does — it has
a top-level `export {}`, so if the real `@earendil-works/pi-coding-agent`
types were ever unavailable under `--omit=dev`, its augmentation would
be a no-op and the build would break the same way. It happens not to
matter today because `render-result.ts` only ever imports a runtime
value (`getMarkdownTheme`) from `pi-coding-agent`, not a type, so
`tsc` doesn't need its `.d.ts` to resolve that import. Leaving this
as-is: fixing it isn't required for #108, and changing an unrelated
file's semantics inside this PR would widen the diff past what the
issue asks for. Flagging it here rather than silently leaving a
latent landmine unrecorded.

## Blast radius

- `package.json` / `package-lock.json`: `typebox` removed entirely;
  `@earendil-works/pi-tui` moves from `dependencies` to
  `peerDependencies` (optional) + `devDependencies`. No source files
  changed — the two import sites (`websearch.ts`, `render-result.ts`)
  are untouched and keep resolving `pi-tui` the same way at runtime.
- `types/pi-tui.d.ts`: new ambient declaration file, included via the
  existing `tsconfig.dist.json`/`tsconfig.json` `types/**/*.d.ts`
  glob. Does not ship in the npm package (not listed in `files`) —
  it's a build-time-only shim, same as the other files in `types/`.
- `.github/workflows/ci.yml`: the two `ERR_MODULE_NOT_FOUND` allowlists
  (prod-install-build, install-test) now also accept `pi-tui` missing
  under `--omit=dev`, matching how `pi-coding-agent`'s absence is
  already treated. The production-dependency audit comment now says
  "both peers" instead of "the only peer".
- No behavior change for anyone running under real pi — pi already
  supplies both packages from its own runtime; this only stops a
  redundant local copy from being installed and fixes the build path
  that copy was accidentally propping up.

Closes #108
