### PR TITLE
feat: add supported static web fetch API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Verify packed static fetch entrypoint without browser or pi peers
+        run: npm run test:webfetch-package
+
       - name: Run full test suite (all suites)
         # One invocation — Node 24 --experimental-strip-types handles all
         # .mjs files and their .ts imports in ~8s (was 4m50s with tsx).
@@ -176,6 +179,10 @@ jobs:
           tar -tzf "$TARBALL" | grep "package/dist/index.js" || \
             (echo "ERROR: dist/index.js missing from tarball" \
               "(prepare build failed?)" && exit 1)
+          tar -tzf "$TARBALL" | grep "package/dist/src/webfetch.js" || \
+            (echo "ERROR: static webfetch JavaScript missing from tarball" && exit 1)
+          tar -tzf "$TARBALL" | grep "package/dist/src/webfetch.d.ts" || \
+            (echo "ERROR: static webfetch declarations missing from tarball" && exit 1)
           # Guard against accidentally shipping TS source again
           # (reintroduces the jiti transpile-on-startup cost).
           if tar -tzf "$TARBALL" | grep -E \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ All notable changes to pi-webaio will be documented in this file.
 
 ### Added
 
+- **Supported static fetch API** — `pi-webaio/webfetch` exports `fetch` and `fetchPage` for integrations that need fingerprinted HTTP fetch and local extraction without registering tools, starting a browser, contacting a remote reader, or writing a content cache. The API propagates cancellation, manually validates and pins each HTTP or client-side redirect, caps aggregate retry and redirect input at 10 MiB, supports five output formats, and exposes Defuddle image/reply controls.
+
 ### Changed
 
 ### Fixed
 
+- **Public-network guard coverage** — the SSRF guard denies non-public IPv4 and IPv6 special-purpose ranges by default, preserves the IANA globally reachable exceptions, handles canonical mapped/compatible/NAT64/6to4/Teredo encodings, and keeps transition-encoded cloud metadata addresses outside the CIDR allow-list.
 - **Tool registration crash when the `@earendil-works/pi-coding-agent` peer is unresolvable** — `src/tools/render-result.ts` statically value-imported `getMarkdownTheme` from the peer, which aborted `aio-webfetch`/`aio-webpull` registration at load time on installs where the peer is not hoisted into the extension's resolution path (e.g. `pi install npm:pi-webaio` copies under `~/.pi/agent/npm/node_modules/` on Linux). The theme now resolves via a lazy dynamic import cached at module load with an unstyled identity-theme fallback, so registration and rendering succeed regardless of peer availability; when the peer resolves, behavior is unchanged. Also fixed lint blockers in the same file (nested ternaries in the progress-bar background lookup, inverted negation ternary in the outline word-count line).
 ## [1.0.5] - 2026-09-03
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,54 @@ Or from git:
 pi install git:github.com/apmantza/pi-webaio
 ```
 
+## Static Fetch API
+
+Use `pi-webaio/webfetch` when an integration needs local extraction without
+registering the eight `aio-*` tools:
+
+```js
+import { fetch } from "pi-webaio/webfetch";
+
+const abortController = new AbortController();
+const result = await fetch("https://example.com/article", {
+  format: "markdown",
+  maxChars: 50_000,
+  signal: abortController.signal,
+});
+
+if (!result.ok) throw new Error(`${result.error.code}: ${result.error.message}`);
+console.log(result.content);
+```
+
+The entrypoint uses `wreq-js` TLS fingerprinting and local Defuddle extraction.
+It does not start a browser, call a remote reader, register pi tools, or write a
+content cache. HTTP and literal client-side redirects are followed manually.
+For direct requests, each destination is checked by the public-network guard
+and pinned into the `wreq-js` transport before connection. Cross-origin
+redirects retain only `Accept`, `Accept-Language`, and `User-Agent` from the
+request headers.
+
+The default call budget is 15 seconds, including bounded cleanup. The call can
+download up to 10 MiB across all retry attempts and redirect responses, then
+return up to 50,000 characters. It follows at most ten redirects and retries a
+failed hop at most twice. The input cap cannot exceed 10 MiB.
+
+Header names and values are validated before a request. Transport-controlled
+framing headers such as `Host` and `Content-Length` are rejected.
+
+`format` accepts `markdown`, `html`, `text`, `json`, or `raw`. `html` requires
+an HTML response and returns Defuddle's cleaned HTML. `json` requires a JSON
+response and returns pretty-printed JSON text. `text` removes markup from HTML
+and XML. `raw` returns the decoded textual response before extraction; binary
+responses are rejected. HTML extraction accepts `removeImages` and
+`includeReplies`.
+
+A configured proxy is checked and pinned before connection. HTTP(S) forward
+proxies and `socks5h` proxies can resolve the target independently, so target
+pinning cannot be enforced through those modes. Use them only with a proxy
+whose destination policy you trust. Successful results report
+`targetPinning: "proxy-dependent"` when a proxy is configured.
+
 ## Documentation
 
 - [Features](docs/features.md) — overview, extraction pipeline, GitHub/YouTube

--- a/package.json
+++ b/package.json
@@ -30,6 +30,17 @@
   ],
   "type": "module",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./webfetch": {
+      "types": "./dist/src/webfetch.d.ts",
+      "import": "./dist/src/webfetch.js"
+    }
+  },
   "imports": {
     "#stealth-script": "./extractors/stealth-script.mjs"
   },
@@ -77,6 +88,8 @@
     "test:render": "node --experimental-strip-types --test tests/render-result.test.mjs",
     "test:fetcherror": "node --experimental-strip-types --test tests/fetch-error.test.mjs",
     "test:fetchprogress": "node --experimental-strip-types --test tests/fetch-progress.test.mjs",
+    "test:webfetch-api": "node --experimental-strip-types --test tests/static-webfetch-api.test.mjs",
+    "test:webfetch-package": "node scripts/test-static-webfetch-package.mjs",
     "test:hardening": "node --experimental-strip-types --test tests/hardening.test.mjs",
     "test:redact": "node --experimental-strip-types --test tests/redact.test.mjs",
     "test:ssrf": "node --experimental-strip-types --test tests/ssrf-hardening.test.mjs",
@@ -108,7 +121,7 @@
     "test:ux-compact-search": "node --experimental-strip-types --test tests/ux-compact-search.test.mjs",
     "test:ux-multi-answer": "node --experimental-strip-types --test tests/ux-multi-answer.test.mjs",
     "test:extraction-quality": "node --experimental-strip-types --test tests/extraction-quality.test.mjs",
-    "test:all": "node --experimental-strip-types --test tests/unit.test.mjs tests/startup-lazy.test.mjs tests/tui-compat.test.mjs tests/websearch-google-flag.test.mjs tests/google-cdp-broker.test.mjs tests/google-cdp-broker-process.test.mjs tests/google-cdp-broker-cdp.test.mjs tests/google-cdp-broker-client.test.mjs tests/google-ai-broker.test.mjs tests/google-search-waits.test.mjs tests/new-features.test.mjs tests/paywall.test.mjs tests/github-check.test.mjs tests/reddit-block.test.mjs tests/reddit-search.test.mjs tests/github-map.test.mjs tests/render-result.test.mjs tests/fetch-error.test.mjs tests/fetch-progress.test.mjs tests/hardening.test.mjs tests/fingerprint.test.mjs tests/format.test.mjs tests/webfetch-summary.test.mjs tests/search-context.test.mjs tests/chunker.test.mjs tests/prune-markdown.test.mjs tests/integration.test.mjs tests/bench-harness.test.mjs tests/webresearch.test.mjs tests/source-ranking.test.mjs tests/cookie-cache.test.mjs tests/goggles.test.mjs tests/stance.test.mjs tests/bot-wait.test.mjs tests/ssrf-allowlist.test.mjs tests/lifecycle-hooks.test.mjs tests/webquery.test.mjs tests/ssrf-hardening.test.mjs tests/redact.test.mjs tests/title-extraction.test.mjs tests/source-trust.test.mjs tests/diagnose-backends.test.mjs tests/security-crosscheck.test.mjs tests/verticals-context7-deepwiki.test.mjs tests/search-diversity.test.mjs tests/content-hash-dedup.test.mjs tests/local-precheck.test.mjs tests/escalation-404.test.mjs tests/batch-throw-isolation.test.mjs tests/debug.test.mjs tests/search-engine-status.test.mjs tests/search-orchestration.test.mjs tests/browser-obs.test.mjs tests/obs-small-wins.test.mjs tests/perf-extraction.test.mjs tests/perf-browser-pool.test.mjs tests/perf-search-deadline.test.mjs tests/perf-workers-cache.test.mjs tests/ux-webfetch-output.test.mjs tests/ux-compact-search.test.mjs tests/ux-multi-answer.test.mjs tests/extraction-quality.test.mjs tests/search-render.test.mjs tests/websearch-default-captcha.test.mjs",
+    "test:all": "node --experimental-strip-types --test tests/unit.test.mjs tests/startup-lazy.test.mjs tests/tui-compat.test.mjs tests/websearch-google-flag.test.mjs tests/google-cdp-broker.test.mjs tests/google-cdp-broker-process.test.mjs tests/google-cdp-broker-cdp.test.mjs tests/google-cdp-broker-client.test.mjs tests/google-ai-broker.test.mjs tests/google-search-waits.test.mjs tests/new-features.test.mjs tests/paywall.test.mjs tests/github-check.test.mjs tests/reddit-block.test.mjs tests/reddit-search.test.mjs tests/github-map.test.mjs tests/render-result.test.mjs tests/fetch-error.test.mjs tests/fetch-progress.test.mjs tests/static-webfetch-api.test.mjs tests/hardening.test.mjs tests/fingerprint.test.mjs tests/format.test.mjs tests/webfetch-summary.test.mjs tests/search-context.test.mjs tests/chunker.test.mjs tests/prune-markdown.test.mjs tests/integration.test.mjs tests/bench-harness.test.mjs tests/webresearch.test.mjs tests/source-ranking.test.mjs tests/cookie-cache.test.mjs tests/goggles.test.mjs tests/stance.test.mjs tests/bot-wait.test.mjs tests/ssrf-allowlist.test.mjs tests/lifecycle-hooks.test.mjs tests/webquery.test.mjs tests/ssrf-hardening.test.mjs tests/redact.test.mjs tests/title-extraction.test.mjs tests/source-trust.test.mjs tests/diagnose-backends.test.mjs tests/security-crosscheck.test.mjs tests/verticals-context7-deepwiki.test.mjs tests/search-diversity.test.mjs tests/content-hash-dedup.test.mjs tests/local-precheck.test.mjs tests/escalation-404.test.mjs tests/batch-throw-isolation.test.mjs tests/debug.test.mjs tests/search-engine-status.test.mjs tests/search-orchestration.test.mjs tests/browser-obs.test.mjs tests/obs-small-wins.test.mjs tests/perf-extraction.test.mjs tests/perf-browser-pool.test.mjs tests/perf-search-deadline.test.mjs tests/perf-workers-cache.test.mjs tests/ux-webfetch-output.test.mjs tests/ux-compact-search.test.mjs tests/ux-multi-answer.test.mjs tests/extraction-quality.test.mjs tests/search-render.test.mjs tests/websearch-default-captcha.test.mjs",
     "check:lockfile": "node scripts/check-lockfile-sync.mjs",
     "changelog:check": "node scripts/changelog-release.mjs --check",
     "changelog:release": "node scripts/changelog-release.mjs",

--- a/scripts/test-static-webfetch-package.mjs
+++ b/scripts/test-static-webfetch-package.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+	existsSync,
+	mkdtempSync,
+	mkdirSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const temp = mkdtempSync(join(tmpdir(), "pi-webaio-webfetch-package-"));
+let tarball;
+
+function run(command, args, cwd, env = process.env) {
+	return execFileSync(command, args, {
+		cwd,
+		env,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+}
+
+function filesBelow(directory, prefix = "") {
+	const entries = [];
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+		if (entry.isDirectory()) entries.push(...filesBelow(join(directory, entry.name), relative));
+		else entries.push(relative);
+	}
+	return entries.sort();
+}
+
+try {
+	run(npm, ["run", "build:dist"], root);
+	const pack = JSON.parse(run(npm, ["pack", "--json", "--ignore-scripts"], root));
+	tarball = resolve(root, pack[0].filename);
+	const consumer = join(temp, "consumer");
+	const state = join(temp, "state");
+	mkdirSync(consumer, { recursive: true });
+	mkdirSync(state, { recursive: true });
+	writeFileSync(
+		join(consumer, "package.json"),
+		JSON.stringify({ name: "pi-webaio-static-api-smoke", private: true, type: "module" }),
+	);
+	const isolatedEnv = {
+		...process.env,
+		HOME: state,
+		TMPDIR: state,
+		TEMP: state,
+		TMP: state,
+	};
+	run(
+		npm,
+		["install", "--ignore-scripts", "--omit=peer", tarball],
+		consumer,
+		isolatedEnv,
+	);
+
+	// The static entrypoint must load without either browser implementation or
+	// pi's host-provided peer packages. Keep wreq's platform binding installed.
+	for (const browserPackage of ["playwright", "playwright-core"]) {
+		rmSync(join(consumer, "node_modules", browserPackage), {
+			recursive: true,
+			force: true,
+		});
+		assert.equal(existsSync(join(consumer, "node_modules", browserPackage)), false);
+	}
+	rmSync(join(consumer, "node_modules", "@earendil-works"), {
+		recursive: true,
+		force: true,
+	});
+	const before = filesBelow(state);
+	writeFileSync(
+		join(consumer, "smoke.mjs"),
+		`import assert from "node:assert/strict";
+const before = new Set(process._getActiveHandles());
+const api = await import("pi-webaio/webfetch");
+assert.equal(typeof api.fetch, "function");
+assert.equal(typeof api.fetchPage, "function");
+assert.equal(api.createStaticWebFetcher, undefined);
+await new Promise((resolve) => setImmediate(resolve));
+const unexpected = process._getActiveHandles().filter((handle) =>
+  !before.has(handle) && ![process.stdin, process.stdout, process.stderr].includes(handle),
+);
+assert.deepEqual(unexpected.map((handle) => handle.constructor?.name ?? "unknown"), []);
+`,
+	);
+	run(process.execPath, ["smoke.mjs"], consumer, isolatedEnv);
+	assert.deepEqual(filesBelow(state), before);
+	console.log(`Static webfetch package smoke passed: ${basename(tarball)}`);
+} finally {
+	if (tarball) rmSync(tarball, { force: true });
+	rmSync(temp, { recursive: true, force: true });
+}

--- a/src/security.ts
+++ b/src/security.ts
@@ -19,24 +19,31 @@ const BLOCKED_HOSTS = new Set([
 function isPrivateIPv4(ip: string): boolean {
 	const parts = ip.split(".").map((x) => Number(x));
 	if (parts.length !== 4 || parts.some((x) => Number.isNaN(x))) return true;
-	const [a, b] = parts as [number, number];
+	const [a, b, c, d] = parts as [number, number, number, number];
+	// RFC 7723 and RFC 8155 carve two globally reachable anycast hosts out
+	// of the otherwise non-public 192.0.0.0/24 protocol-assignment block.
+	if (a === 192 && b === 0 && c === 0 && (d === 9 || d === 10)) return false;
 	return (
+		a === 0 || // "this" network
 		a === 10 || // RFC 1918
 		a === 127 || // loopback
-		(a === 172 && b >= 16 && b <= 31) || // RFC 1918
-		(a === 192 && b === 168) || // RFC 1918
+		(a === 100 && b >= 64 && b <= 127) || // shared address space (RFC 6598)
 		(a === 169 && b === 254) || // link-local
-		(a === 100 && b >= 64 && b <= 127) || // CGN (RFC 6598)
+		(a === 172 && b >= 16 && b <= 31) || // RFC 1918
+		(a === 192 && b === 0 && c === 0) || // IETF protocol assignments
+		(a === 192 && b === 0 && c === 2) || // TEST-NET-1
+		(a === 192 && b === 88 && c === 99) || // deprecated 6to4 relay anycast
+		(a === 192 && b === 168) || // RFC 1918
 		(a === 198 && (b === 18 || b === 19)) || // benchmarking (RFC 2544)
-		a === 0 // "this" network
+		(a === 198 && b === 51 && c === 100) || // TEST-NET-2
+		(a === 203 && b === 0 && c === 113) || // TEST-NET-3
+		a >= 224 // multicast and reserved
 	);
 }
 
 function isPrivateIPv6(ip: string): boolean {
 	const n = ip.toLowerCase();
 	if (n === "::1" || n === "::") return true;
-	if (n.startsWith("fc") || n.startsWith("fd") || n.startsWith("fe80"))
-		return true;
 
 	const v4Mapped = n.match(/^::ffff:([\d.]+)$/);
 	if (v4Mapped) return isPrivateIPv4(v4Mapped[1]!);
@@ -50,17 +57,96 @@ function isPrivateIPv6(ip: string): boolean {
 	// approach as the 6to4 / Teredo string checks below).
 	const bytes = ipv6ToBytes(n);
 	if (bytes) {
-		// NAT64 (RFC 6052 64:ff9b::/96 and RFC 8215 64:ff9b:1::/48): the
-		// embedded IPv4 lives in the final 32 bits.
+		// Unique-local fc00::/7, link-local fe80::/10, and multicast ff00::/8.
+		if ((bytes[0]! & 0xfe) === 0xfc) return true;
+		if (bytes[0] === 0xfe && (bytes[1]! & 0xc0) === 0x80) return true;
+		if (bytes[0] === 0xff) return true;
+
+		// 64:ff9b:1::/48 is the local-use translation prefix and is not
+		// globally reachable. 64:ff9b::/96 is globally reachable, so permit it
+		// only when its embedded IPv4 destination is public.
 		const nat64Prefix =
 			bytes[0] === 0x00 &&
 			bytes[1] === 0x64 &&
 			bytes[2] === 0xff &&
 			bytes[3] === 0x9b;
-		const nat64_96 = nat64Prefix && bytes.subarray(4, 12).every((b) => b === 0);
 		const nat64_48 = nat64Prefix && bytes[4] === 0x00 && bytes[5] === 0x01;
-		if (nat64_96 || nat64_48) {
+		if (nat64_48) return true;
+		const nat64_96 = nat64Prefix && bytes.subarray(4, 12).every((b) => b === 0);
+		if (nat64_96) {
 			return isPrivateIPv4(`${bytes[12]}.${bytes[13]}.${bytes[14]}.${bytes[15]}`);
+		}
+
+		// 6to4 embeds the destination IPv4 address in bits 16–48. Teredo
+		// stores the client's IPv4 address, one's-complemented, in the final
+		// 32 bits. Use bytes so compressed IPv6 spellings cannot bypass the
+		// embedded-address checks.
+		if (bytes[0] === 0x20 && bytes[1] === 0x02) {
+			return isPrivateIPv4(`${bytes[2]}.${bytes[3]}.${bytes[4]}.${bytes[5]}`);
+		}
+		if (
+			bytes[0] === 0x20 &&
+			bytes[1] === 0x01 &&
+			bytes[2] === 0x00 &&
+			bytes[3] === 0x00
+		) {
+			return isPrivateIPv4(
+				`${bytes[12]! ^ 0xff}.${bytes[13]! ^ 0xff}.${bytes[14]! ^ 0xff}.${bytes[15]! ^ 0xff}`,
+			);
+		}
+
+		// The IANA IPv6 special-purpose registry marks these ranges as not
+		// globally reachable.
+		if (
+			bytes[0] === 0x01 &&
+			bytes[1] === 0x00 &&
+			bytes[2] === 0x00 &&
+			bytes[3] === 0x00 &&
+			bytes[4] === 0x00 &&
+			bytes[5] === 0x00 &&
+			bytes[6] === 0x00 &&
+			bytes[7] === 0x01
+		)
+			return true; // 100:0:0:1::/64 dummy prefix
+		if (
+			bytes[0] === 0x20 &&
+			bytes[1] === 0x01 &&
+			bytes[2] === 0x0d &&
+			bytes[3] === 0xb8
+		)
+			return true; // 2001:db8::/32 documentation
+		if (
+			bytes[0] === 0x3f &&
+			bytes[1] === 0xff &&
+			(bytes[2]! & 0xf0) === 0
+		)
+			return true; // 3fff::/20 documentation
+		if (bytes[0] === 0x5f && bytes[1] === 0x00) return true; // SRv6 SIDs
+
+		// 2001::/23 is non-public except for six globally reachable ranges.
+		// Teredo was handled by the embedded-address check above.
+		const inIetfAssignments =
+			bytes[0] === 0x20 && bytes[1] === 0x01 && (bytes[2]! & 0xfe) === 0;
+		if (inIetfAssignments) {
+			const isAnycast =
+				bytes[2] === 0 &&
+				bytes[3] === 1 &&
+				bytes.subarray(4, 15).every((b) => b === 0) &&
+				(bytes[15] === 1 || bytes[15] === 2 || bytes[15] === 3);
+			const isAmt = bytes[2] === 0 && bytes[3] === 3;
+			const isAs112 =
+				bytes[2] === 0 && bytes[3] === 4 && bytes[4] === 1 && bytes[5] === 0x12;
+			const isOrchidV2 =
+				bytes[2] === 0 && (bytes[3]! & 0xf0) === 0x20;
+			const isDroneDet = bytes[2] === 0 && (bytes[3]! & 0xf0) === 0x30;
+			if (
+				!isAnycast &&
+				!isAmt &&
+				!isAs112 &&
+				!isOrchidV2 &&
+				!isDroneDet
+			)
+				return true;
 		}
 		// IPv4-mapped hex form ::ffff:XXYY:ZZWW (the dotted-quad form is
 		// handled by the regex above; this catches the hex spelling).
@@ -68,35 +154,10 @@ function isPrivateIPv6(ip: string): boolean {
 			bytes.subarray(0, 10).every((b) => b === 0) &&
 			bytes[10] === 0xff &&
 			bytes[11] === 0xff;
-		if (mappedHex) {
+		const compatibleHex = bytes.subarray(0, 12).every((b) => b === 0);
+		if (mappedHex || compatibleHex) {
 			return isPrivateIPv4(`${bytes[12]}.${bytes[13]}.${bytes[14]}.${bytes[15]}`);
 		}
-	}
-
-	const sixTo4 = n.match(
-		/^2002:([0-9a-f]{2})([0-9a-f]{2}):([0-9a-f]{2})([0-9a-f]{2})/i,
-	);
-	if (sixTo4) {
-		const v4 = [
-			parseInt(sixTo4[1]!, 16),
-			parseInt(sixTo4[2]!, 16),
-			parseInt(sixTo4[3]!, 16),
-			parseInt(sixTo4[4]!, 16),
-		].join(".");
-		return isPrivateIPv4(v4);
-	}
-
-	const teredo = n.match(
-		/^2001:0(?:000)?:.*?:([0-9a-f]{2})([0-9a-f]{2}):([0-9a-f]{2})([0-9a-f]{2})$/i,
-	);
-	if (teredo) {
-		const v4 = [
-			parseInt(teredo[1]!, 16) ^ 0xff,
-			parseInt(teredo[2]!, 16) ^ 0xff,
-			parseInt(teredo[3]!, 16) ^ 0xff,
-			parseInt(teredo[4]!, 16) ^ 0xff,
-		].join(".");
-		return isPrivateIPv4(v4);
 	}
 
 	return false;
@@ -140,26 +201,64 @@ export function isCloudMetadataIp(ip: string): boolean {
 	if (version === 6) {
 		const n = ip.toLowerCase();
 		if (METADATA_IPV6.has(n)) return true;
-		// IPv4-mapped (::ffff:a.b.c.d) / IPv4-compatible (::a.b.c.d) forms
-		// embedding a metadata IPv4 address.
-		const embedded = n.match(/^::(?:ffff:)?([\d.]+)$/);
-		if (embedded) return METADATA_IPV4.has(embedded[1]!);
-		// Hex-spelled IPv4-mapped/compatible forms (e.g. ::ffff:a9fe:a9fe =
-		// 169.254.169.254). Resolve via bytes so the metadata floor cannot be
-		// bypassed by choosing the hex encoding of a mapped metadata address.
-		const bytes = ipv6ToBytes(n);
-		if (bytes) {
-			const allZeroHigh = bytes.subarray(0, 10).every((b) => b === 0);
-			const mapped = allZeroHigh && bytes[10] === 0xff && bytes[11] === 0xff;
-			const compat = allZeroHigh && bytes[10] === 0x00 && bytes[11] === 0x00;
-			if (mapped || compat) {
-				const v4 = `${bytes[12]}.${bytes[13]}.${bytes[14]}.${bytes[15]}`;
-				if (METADATA_IPV4.has(v4)) return true;
-			}
-		}
-		return false;
+		return embeddedIpv4Candidates(n).some((v4) => METADATA_IPV4.has(v4));
 	}
 	return false;
+}
+
+/**
+ * Decode IPv4 destinations carried by mapped, compatible, NAT64, 6to4, and
+ * Teredo IPv6 addresses. Multiple NAT64 local-prefix layouts are returned
+ * because RFC 6052 permits several prefix lengths under 64:ff9b:1::/48.
+ */
+function embeddedIpv4Candidates(ip: string): string[] {
+	const bytes = ipv6ToBytes(ip.toLowerCase());
+	if (!bytes) return [];
+	const out: string[] = [];
+	const add = (a: number, b: number, c: number, d: number): void => {
+		const candidate = `${a}.${b}.${c}.${d}`;
+		if (!out.includes(candidate)) out.push(candidate);
+	};
+
+	const mapped =
+		bytes.subarray(0, 10).every((b) => b === 0) &&
+		bytes[10] === 0xff &&
+		bytes[11] === 0xff;
+	const compatible = bytes.subarray(0, 12).every((b) => b === 0);
+	if (mapped || compatible) add(bytes[12]!, bytes[13]!, bytes[14]!, bytes[15]!);
+
+	const nat64Prefix =
+		bytes[0] === 0x00 &&
+		bytes[1] === 0x64 &&
+		bytes[2] === 0xff &&
+		bytes[3] === 0x9b;
+	if (nat64Prefix && bytes.subarray(4, 12).every((b) => b === 0)) {
+		add(bytes[12]!, bytes[13]!, bytes[14]!, bytes[15]!); // /96
+	}
+	if (nat64Prefix && bytes[4] === 0 && bytes[5] === 1) {
+		add(bytes[6]!, bytes[7]!, bytes[9]!, bytes[10]!); // /48
+		add(bytes[7]!, bytes[9]!, bytes[10]!, bytes[11]!); // /56
+		add(bytes[9]!, bytes[10]!, bytes[11]!, bytes[12]!); // /64
+		add(bytes[12]!, bytes[13]!, bytes[14]!, bytes[15]!); // defensive
+	}
+
+	if (bytes[0] === 0x20 && bytes[1] === 0x02) {
+		add(bytes[2]!, bytes[3]!, bytes[4]!, bytes[5]!);
+	}
+	if (
+		bytes[0] === 0x20 &&
+		bytes[1] === 0x01 &&
+		bytes[2] === 0x00 &&
+		bytes[3] === 0x00
+	) {
+		add(
+			bytes[12]! ^ 0xff,
+			bytes[13]! ^ 0xff,
+			bytes[14]! ^ 0xff,
+			bytes[15]! ^ 0xff,
+		);
+	}
+	return out;
 }
 
 // ─── SSRF allow-list (CIDR ranges) ─────────────────────────────────
@@ -343,7 +442,12 @@ function getAllowRanges(): ParsedCidr[] {
 /** Returns true if `ip` is permitted by the configured allow-list. */
 function isAllowed(ip: string, ranges: ParsedCidr[]): boolean {
 	if (ranges.length === 0) return false;
-	return ranges.some((r) => ipMatchesCidr(ip, r));
+	if (ranges.some((r) => ipMatchesCidr(ip, r))) return true;
+	// IPv4-compatible IPv6 literals are canonicalized to hex by URL parsing.
+	// Let an explicit IPv4 allow-range apply to the same embedded destination.
+	return embeddedIpv4Candidates(ip).some((v4) =>
+		ranges.some((r) => ipMatchesCidr(v4, r)),
+	);
 }
 
 /**

--- a/src/security.ts
+++ b/src/security.ts
@@ -516,7 +516,7 @@ const defaultDnsResolver: DnsResolver = async (host) => {
 	return records.map((r) => ({ address: r.address, family: r.family }));
 };
 
-interface SsrfValidation {
+export interface SsrfValidation {
 	/** True when the URL must be blocked. */
 	dangerous: boolean;
 	/** Machine-readable reason when dangerous (e.g. "cloud-metadata"). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type PdfParseCtor = new (opts: {
 }) => {
 	load: () => Promise<void>;
 	getText: () => Promise<{ text: string; total: number }>;
+	destroy: () => Promise<void>;
 };
 
 function ensurePdfDomPolyfills(): void {

--- a/src/webfetch-api.ts
+++ b/src/webfetch-api.ts
@@ -1,0 +1,1514 @@
+import { isIP } from "node:net";
+import { Defuddle } from "defuddle/node";
+import { parseHTML } from "linkedom";
+import {
+	createTransport as createWreqTransport,
+	fetch as wreqFetch,
+	getOperatingSystems,
+	getProfiles,
+} from "wreq-js";
+import type { BrowserAlias, BrowserProfile, EmulationOS } from "wreq-js";
+import { detectBotBlock } from "./bot-detection.ts";
+import { redactSecrets } from "./redact.ts";
+import {
+	scanForSecrets,
+	validateUrlForSsrf,
+	type SsrfValidation,
+} from "./security.ts";
+import { loadPdfParseCtor, type PdfParseCtor } from "./types.ts";
+
+export const DEFAULT_WEBFETCH_BROWSER = "chrome_145";
+export const DEFAULT_WEBFETCH_OS = "windows";
+export const DEFAULT_WEBFETCH_TIMEOUT_MS = 15_000;
+export const DEFAULT_MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+export const DEFAULT_MAX_OUTPUT_CHARS = 50_000;
+export const DEFAULT_MAX_REDIRECTS = 10;
+export const DEFAULT_MAX_RETRIES = 2;
+
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+const REDIRECT_STATUS = new Set([301, 302, 303, 307, 308]);
+const SUPPORTED_FORMATS = new Set<StaticWebFetchFormat>([
+	"markdown",
+	"html",
+	"text",
+	"json",
+	"raw",
+]);
+const CROSS_ORIGIN_HEADER_ALLOWLIST = new Set([
+	"accept",
+	"accept-language",
+	"user-agent",
+]);
+const BROWSER_ALIASES = new Set([
+	"chrome",
+	"edge",
+	"firefox",
+	"firefox_android",
+	"firefox_private",
+	"okhttp",
+	"opera",
+	"safari",
+	"safari_ios",
+	"safari_ipad",
+]);
+const CREDENTIAL_PARAMETER = /^(?:(?:x[-_](?:amz|goog))[-_])?(?:access[-_]?key|access[-_]?token|api[-_]?key|auth(?:orization)?|bearer|client[-_]?secret|credential|csrf|id[-_]?token|jwt|oauth[-_]?token|password|passwd|private[-_]?key|refresh[-_]?token|secret(?:[-_]?key)?|security[-_]?token|session(?:[-_]?id)?|signature|sig|token|xsrf)$/i;
+const HTTP_HEADER_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const FORBIDDEN_REQUEST_HEADERS = new Set([
+	"connection",
+	"content-length",
+	"host",
+	"proxy-connection",
+	"te",
+	"trailer",
+	"transfer-encoding",
+	"upgrade",
+]);
+const ALLOWED_OPTION_NAMES = new Set([
+	"browser",
+	"os",
+	"headers",
+	"proxy",
+	"timeoutMs",
+	"maxChars",
+	"maxResponseBytes",
+	"maxRedirects",
+	"maxRetries",
+	"format",
+	"removeImages",
+	"includeReplies",
+	"signal",
+]);
+const CLEANUP_WAIT_MS = 100;
+
+export type StaticWebFetchFormat = "markdown" | "html" | "text" | "json" | "raw";
+export type StaticWebFetchReplyPolicy = boolean | "extractors";
+
+export interface StaticWebFetchOptions {
+	browser?: BrowserProfile | BrowserAlias;
+	os?: EmulationOS;
+	headers?: Record<string, string>;
+	proxy?: string;
+	timeoutMs?: number;
+	maxChars?: number;
+	maxResponseBytes?: number;
+	maxRedirects?: number;
+	maxRetries?: number;
+	format?: StaticWebFetchFormat;
+	removeImages?: boolean;
+	includeReplies?: StaticWebFetchReplyPolicy;
+	signal?: AbortSignal;
+}
+
+export type StaticWebFetchErrorCode =
+	| "invalid_url"
+	| "unsupported_protocol"
+	| "invalid_option"
+	| "blocked_secret"
+	| "blocked_ssrf"
+	| "dns_error"
+	| "too_many_redirects"
+	| "redirect_loop"
+	| "aborted"
+	| "timeout"
+	| "network_error"
+	| "http_error"
+	| "response_too_large"
+	| "binary_content"
+	| "unexpected_content_type"
+	| "parse_error"
+	| "bot_detected"
+	| "no_content";
+
+export interface StaticWebFetchError {
+	code: StaticWebFetchErrorCode;
+	message: string;
+	phase: "validation" | "connecting" | "waiting" | "loading" | "processing";
+	retryable: boolean;
+	statusCode?: number;
+}
+
+export interface StaticWebFetchSuccess {
+	ok: true;
+	kind: "content";
+	url: string;
+	finalUrl: string;
+	redirects: string[];
+	statusCode: number;
+	statusText: string;
+	contentType?: string;
+	format: StaticWebFetchFormat;
+	content: string;
+	truncated: boolean;
+	title: string;
+	author: string;
+	published: string;
+	site: string;
+	language: string;
+	description: string;
+	/** Word count for the full extracted content before maxChars truncation. */
+	wordCount: number;
+	fullContentChars: number;
+	outputChars: number;
+	browser: BrowserProfile | BrowserAlias;
+	os: EmulationOS;
+	downloadedBytes: number;
+	contentLength: number | null;
+	elapsedMs: number;
+	browserEscalated: false;
+	remoteFallbackUsed: false;
+	persisted: false;
+	proxyUsed: boolean;
+	targetPinning: "local" | "proxy-dependent";
+}
+
+export interface StaticWebFetchFailure {
+	ok: false;
+	url: string;
+	finalUrl?: string;
+	redirects: string[];
+	elapsedMs: number;
+	error: StaticWebFetchError;
+}
+
+export type StaticWebFetchResult = StaticWebFetchSuccess | StaticWebFetchFailure;
+
+interface HeaderReader {
+	get(name: string): string | null;
+}
+
+interface BodyReader {
+	read(): Promise<{ done: boolean; value?: Uint8Array }>;
+	cancel(): unknown;
+}
+
+interface ResponseBody {
+	getReader(): BodyReader;
+	cancel?(): unknown;
+}
+
+interface StaticResponse {
+	url?: string;
+	status: number;
+	statusText?: string;
+	ok?: boolean;
+	headers: HeaderReader;
+	body?: ResponseBody | null;
+	arrayBuffer?(): Promise<ArrayBuffer>;
+}
+
+interface StaticTransport {
+	close(): Promise<void>;
+}
+
+export interface StaticWebFetchDependencies {
+	validateUrl(url: string): Promise<SsrfValidation>;
+	createTransport(options: {
+		browser: BrowserProfile | BrowserAlias;
+		os: EmulationOS;
+		proxy?: string;
+		resolve?: Record<string, string[]>;
+	}): Promise<StaticTransport>;
+	request(
+		url: string,
+		init: {
+			redirect: "manual";
+			headers: Record<string, string>;
+			signal: AbortSignal;
+			timeout: number;
+			transport: StaticTransport;
+		},
+	): Promise<StaticResponse>;
+	sleep(ms: number): Promise<void>;
+	loadPdfParser(): Promise<PdfParseCtor>;
+}
+
+interface ByteBudget {
+	remaining: number;
+	total: number;
+}
+
+interface DownloadedResponse {
+	url: string;
+	status: number;
+	statusText: string;
+	headers: HeaderReader;
+	body: Uint8Array;
+	downloadedBytes: number;
+	contentLength: number | null;
+	redirects: string[];
+}
+
+interface ExtractedContent {
+	content: string;
+	title?: string;
+	author?: string;
+	published?: string;
+	site?: string;
+	language?: string;
+	description?: string;
+	wordCount?: number;
+}
+
+class RetryAttempt extends Error {
+	readonly delayMs: number;
+
+	constructor(delayMs: number) {
+		super("retry request");
+		this.delayMs = delayMs;
+	}
+}
+
+class StaticFetchException extends Error {
+	readonly code: StaticWebFetchErrorCode;
+	readonly phase: StaticWebFetchError["phase"];
+	readonly retryable: boolean;
+	readonly statusCode?: number;
+	readonly finalUrl?: string;
+	readonly redirects: string[];
+
+	constructor(
+		code: StaticWebFetchErrorCode,
+		message: string,
+		options: {
+			phase: StaticWebFetchError["phase"];
+			retryable?: boolean;
+			statusCode?: number;
+			finalUrl?: string;
+			redirects?: string[];
+		},
+	) {
+		super(redactErrorText(message));
+		this.name = "StaticFetchException";
+		this.code = code;
+		this.phase = options.phase;
+		this.retryable = options.retryable ?? false;
+		this.statusCode = options.statusCode;
+		this.finalUrl = options.finalUrl;
+		this.redirects = options.redirects ?? [];
+	}
+}
+
+const defaultDependencies: StaticWebFetchDependencies = {
+	validateUrl: validateUrlForSsrf,
+	createTransport: async (options) => {
+		return createWreqTransport({
+			browser: options.browser,
+			os: options.os,
+			proxy: options.proxy,
+			resolve: options.resolve,
+		});
+	},
+	// SAFETY: the public dependency seam uses the subset of wreq RequestInit
+	// needed by this entrypoint; the default transport is a real wreq Transport.
+	request: async (url, init) => wreqFetch(url, init as any),
+	sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+	loadPdfParser: loadPdfParseCtor,
+};
+
+function numericOption(
+	value: number | undefined,
+	fallback: number,
+	name: string,
+	minimum: number,
+	maximum: number,
+): number {
+	if (value === undefined) return fallback;
+	if (!Number.isFinite(value) || !Number.isInteger(value) || value < minimum || value > maximum) {
+		throw new StaticFetchException(
+			"invalid_option",
+			`${name} must be an integer between ${minimum} and ${maximum}`,
+			{ phase: "validation" },
+		);
+	}
+	return value;
+}
+
+function validateRuntimeOptions(
+	options: StaticWebFetchOptions | null | undefined,
+): asserts options is StaticWebFetchOptions {
+	if (
+		options === null ||
+		options === undefined ||
+		typeof options !== "object" ||
+		Array.isArray(options) ||
+		(Object.getPrototypeOf(options) !== Object.prototype &&
+			Object.getPrototypeOf(options) !== null)
+	) {
+		throw new StaticFetchException("invalid_option", "options must be a plain object", {
+			phase: "validation",
+		});
+	}
+	const unknown = Object.keys(options).filter((name) => !ALLOWED_OPTION_NAMES.has(name));
+	if (unknown.length > 0) {
+		throw new StaticFetchException(
+			"invalid_option",
+			`Unknown option${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}`,
+			{ phase: "validation" },
+		);
+	}
+	if (options.format !== undefined && !SUPPORTED_FORMATS.has(options.format)) {
+		throw new StaticFetchException(
+			"invalid_option",
+			"format must be markdown, html, text, json, or raw",
+			{ phase: "validation" },
+		);
+	}
+	if (
+		options.headers !== undefined &&
+		(typeof options.headers !== "object" ||
+			options.headers === null ||
+			Array.isArray(options.headers) ||
+			(Object.getPrototypeOf(options.headers) !== Object.prototype &&
+				Object.getPrototypeOf(options.headers) !== null) ||
+			Object.values(options.headers).some(
+				(value) => typeof value !== "string" || /[\u0000-\u001f\u007f]/.test(value),
+			) ||
+			Object.keys(options.headers).some(
+				(name) =>
+					!HTTP_HEADER_NAME.test(name) ||
+					FORBIDDEN_REQUEST_HEADERS.has(name.toLowerCase()),
+			))
+	) {
+		throw new StaticFetchException(
+			"invalid_option",
+			"headers contain an invalid or transport-controlled name or value",
+			{ phase: "validation" },
+		);
+	}
+	for (const [name, value] of [
+		["browser", options.browser],
+		["os", options.os],
+		["proxy", options.proxy],
+	] as const) {
+		if (value !== undefined && typeof value !== "string") {
+			throw new StaticFetchException("invalid_option", `${name} must be a string`, {
+				phase: "validation",
+			});
+		}
+	}
+	if (options.browser !== undefined) {
+		let supported = BROWSER_ALIASES.has(options.browser);
+		try {
+			supported ||= getProfiles().includes(options.browser as BrowserProfile);
+		} catch {
+			// Fail closed when a concrete profile cannot be enumerated.
+		}
+		if (!supported) {
+			throw new StaticFetchException("invalid_option", "browser is not a supported wreq profile", {
+				phase: "validation",
+			});
+		}
+	}
+	if (options.os !== undefined) {
+		let supported = ["windows", "macos", "linux", "android", "ios"].includes(options.os);
+		try {
+			supported = getOperatingSystems().includes(options.os);
+		} catch {
+			// Keep the stable public OS list when the native binding cannot enumerate.
+		}
+		if (!supported) {
+			throw new StaticFetchException("invalid_option", "os is not supported by wreq", {
+				phase: "validation",
+			});
+		}
+	}
+	if (options.removeImages !== undefined && typeof options.removeImages !== "boolean") {
+		throw new StaticFetchException("invalid_option", "removeImages must be a boolean", {
+			phase: "validation",
+		});
+	}
+	if (
+		options.includeReplies !== undefined &&
+		typeof options.includeReplies !== "boolean" &&
+		options.includeReplies !== "extractors"
+	) {
+		throw new StaticFetchException(
+			"invalid_option",
+			'includeReplies must be a boolean or "extractors"',
+			{ phase: "validation" },
+		);
+	}
+	if (
+		options.signal !== undefined &&
+		(typeof options.signal !== "object" ||
+			typeof options.signal.aborted !== "boolean" ||
+			typeof options.signal.addEventListener !== "function" ||
+			typeof options.signal.removeEventListener !== "function")
+	) {
+		throw new StaticFetchException("invalid_option", "signal must be an AbortSignal", {
+			phase: "validation",
+		});
+	}
+}
+
+function parseHttpUrl(value: string, label = "URL"): URL {
+	let parsed: URL;
+	try {
+		parsed = new URL(value);
+	} catch {
+		throw new StaticFetchException("invalid_url", `Invalid ${label}: ${redactUrl(value)}`, {
+			phase: "validation",
+		});
+	}
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		throw new StaticFetchException(
+			"unsupported_protocol",
+			`${label} must use http or https, got ${parsed.protocol}`,
+			{ phase: "validation" },
+		);
+	}
+	return parsed;
+}
+
+function abortException(signal: AbortSignal): StaticFetchException {
+	const reason = signal.reason;
+	const timedOut =
+		reason instanceof Error &&
+		((reason as NodeJS.ErrnoException).code === "ETIMEDOUT" ||
+			reason.name === "TimeoutError");
+	return new StaticFetchException(
+		timedOut ? "timeout" : "aborted",
+		timedOut ? "The request timed out" : "The request was aborted",
+		{ phase: "waiting", retryable: timedOut },
+	);
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+	if (signal.aborted) throw abortException(signal);
+}
+
+function raceWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+	if (signal.aborted) return Promise.reject(abortException(signal));
+	return new Promise<T>((resolve, reject) => {
+		const onAbort = () => reject(abortException(signal));
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(
+			(value) => {
+				signal.removeEventListener("abort", onAbort);
+				resolve(value);
+			},
+			(error) => {
+				signal.removeEventListener("abort", onAbort);
+				reject(error);
+			},
+		);
+	});
+}
+
+function requestSignal(parent: AbortSignal | undefined, timeoutMs: number): {
+	signal: AbortSignal;
+	dispose(): void;
+} {
+	const controller = new AbortController();
+	const onParentAbort = () => controller.abort(parent?.reason);
+	if (parent?.aborted) onParentAbort();
+	else parent?.addEventListener("abort", onParentAbort, { once: true });
+	const timer = setTimeout(() => {
+		const error = new Error(`Request timed out after ${timeoutMs}ms`) as NodeJS.ErrnoException;
+		error.code = "ETIMEDOUT";
+		controller.abort(error);
+	}, timeoutMs);
+	timer.unref?.();
+	return {
+		signal: controller.signal,
+		dispose() {
+			clearTimeout(timer);
+			parent?.removeEventListener("abort", onParentAbort);
+		},
+	};
+}
+
+async function boundedCleanup(
+	action: () => Promise<unknown>,
+	signal: AbortSignal,
+): Promise<void> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	let onAbort: (() => void) | undefined;
+	const cleanup = Promise.resolve()
+		.then(action)
+		.catch(() => {});
+	const deadline = new Promise<void>((resolve) => {
+		timer = setTimeout(resolve, CLEANUP_WAIT_MS);
+	});
+	const aborted = new Promise<void>((resolve) => {
+		if (signal.aborted) resolve();
+		else {
+			onAbort = resolve;
+			signal.addEventListener("abort", onAbort, { once: true });
+		}
+	});
+	await Promise.race([cleanup, deadline, aborted]);
+	if (timer) clearTimeout(timer);
+	if (onAbort) signal.removeEventListener("abort", onAbort);
+}
+
+function safeCancel(target: { cancel?: () => unknown } | null | undefined): void {
+	if (!target?.cancel) return;
+	try {
+		const result = target.cancel();
+		if (result && typeof (result as Promise<unknown>).catch === "function") {
+			(result as Promise<unknown>).catch(() => {});
+		}
+	} catch {
+		// Cancellation is best-effort; the transport is also closed in finally.
+	}
+}
+
+async function readBody(
+	response: StaticResponse,
+	budget: ByteBudget,
+	signal: AbortSignal,
+): Promise<{ body: Uint8Array; downloadedBytes: number; contentLength: number | null }> {
+	const header = response.headers.get("content-length");
+	const parsedLength = header === null ? Number.NaN : Number.parseInt(header, 10);
+	const contentLength = Number.isFinite(parsedLength) && parsedLength >= 0 ? parsedLength : null;
+	if (contentLength !== null && contentLength > budget.remaining) {
+		safeCancel(response.body);
+		throw new StaticFetchException(
+			"response_too_large",
+			`Response Content-Length ${contentLength} exceeds the remaining ${budget.remaining} byte input budget`,
+			{ phase: "loading" },
+		);
+	}
+
+	if (!response.body) {
+		if (!response.arrayBuffer) return { body: new Uint8Array(), downloadedBytes: 0, contentLength };
+		const buffer = await raceWithAbort(response.arrayBuffer(), signal);
+		budget.remaining -= buffer.byteLength;
+		budget.total += buffer.byteLength;
+		if (budget.remaining < 0) {
+			throw new StaticFetchException(
+				"response_too_large",
+				"Response exceeded the aggregate input budget",
+				{ phase: "loading" },
+			);
+		}
+		return {
+			body: new Uint8Array(buffer),
+			downloadedBytes: buffer.byteLength,
+			contentLength,
+		};
+	}
+
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let downloadedBytes = 0;
+	try {
+		while (true) {
+			const { done, value } = await raceWithAbort(reader.read(), signal);
+			if (done) break;
+			if (!value) continue;
+			downloadedBytes += value.byteLength;
+			budget.remaining -= value.byteLength;
+			budget.total += value.byteLength;
+			if (budget.remaining < 0) {
+				throw new StaticFetchException(
+					"response_too_large",
+					"Response exceeded the aggregate input budget",
+					{ phase: "loading" },
+				);
+			}
+			chunks.push(value);
+		}
+	} catch (error) {
+		safeCancel(reader);
+		throw error;
+	}
+
+	const body = new Uint8Array(downloadedBytes);
+	let offset = 0;
+	for (const chunk of chunks) {
+		body.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return { body, downloadedBytes, contentLength };
+}
+
+function isRetryableNetworkError(error: unknown): boolean {
+	if (error instanceof StaticFetchException) return error.retryable;
+	const value = error as NodeJS.ErrnoException | undefined;
+	const message = (value?.message ?? String(error)).toLowerCase();
+	return (
+		value?.code === "ECONNRESET" ||
+		value?.code === "ETIMEDOUT" ||
+		value?.code === "EAI_AGAIN" ||
+		message.includes("connection reset") ||
+		message.includes("error sending request") ||
+		message.includes("fetch failed") ||
+		message.includes("timed out")
+	);
+}
+
+function retryDelay(attempt: number): number {
+	return Math.min(4000, 500 * 2 ** attempt);
+}
+
+function requireHostnamePins(
+	parsed: URL,
+	verdict: SsrfValidation,
+	label: "request" | "proxy",
+): void {
+	const host = parsed.hostname.replace(/^\[|\]$/g, "");
+	if (isIP(host)) return;
+	if (
+		verdict.pinnedIps.length === 0 ||
+		verdict.pinnedIps.some((address) => isIP(address) === 0)
+	) {
+		throw new StaticFetchException(
+			"dns_error",
+			`${label === "proxy" ? "Proxy" : "Request"} hostname did not produce validated DNS pins`,
+			{ phase: "validation" },
+		);
+	}
+}
+
+function resolveMap(parsed: URL, pins: string[]): Record<string, string[]> | undefined {
+	const host = parsed.hostname.replace(/^\[|\]$/g, "");
+	if (isIP(host) || pins.length === 0) return undefined;
+	return { [host]: [...pins] };
+}
+
+function headersForCrossOriginRedirect(
+	headers: Record<string, string>,
+): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(headers).filter(([name]) =>
+			CROSS_ORIGIN_HEADER_ALLOWLIST.has(name.toLowerCase()),
+		),
+	);
+}
+
+function redirectTarget(response: StaticResponse, currentUrl: string): string | null {
+	if (!REDIRECT_STATUS.has(response.status)) return null;
+	const location = response.headers.get("location");
+	if (!location) return null;
+	try {
+		return new URL(location, currentUrl).href;
+	} catch {
+		throw new StaticFetchException("invalid_url", "Server returned an invalid redirect URL", {
+			phase: "loading",
+			finalUrl: currentUrl,
+		});
+	}
+}
+
+function clientRedirectTarget(html: string, currentUrl: string): string | null {
+	const snippet = html.slice(0, 4096);
+	const resolve = (target: string): string | null => {
+		const cleaned = target.trim().replace(/^["']|["']$/g, "");
+		if (!cleaned || /[\u0000-\u001f\u007f]/.test(cleaned)) return null;
+		try {
+			const parsed = new URL(cleaned, currentUrl);
+			if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+			return parsed.href === currentUrl ? null : parsed.href;
+		} catch {
+			return null;
+		}
+	};
+	const meta = snippet.match(
+		/<meta[^>]+http-equiv=["']?refresh["']?[^>]+content=["']?([^"'>]*)/i,
+	);
+	if (meta) {
+		const parts = meta[1]!.split(";");
+		const delay = Number.parseFloat(parts[0]!.trim());
+		const match = parts.slice(1).join(";").match(/url\s*=\s*(.+)/i);
+		if (Number.isFinite(delay) && delay >= 0 && delay < 30 && match) {
+			const target = resolve(match[1]!);
+			if (target) return target;
+		}
+	}
+	for (const match of snippet.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/gi)) {
+		const script = match[1] ?? "";
+		const assignment = script.match(
+			/^\s*(?:window\.|document\.)?location(?:\.href)?\s*=\s*(["'])(.*?)\1\s*;?\s*$/i,
+		);
+		const call = script.match(
+			/^\s*(?:window\.|document\.)?location\.(?:replace|assign)\(\s*(["'])(.*?)\1\s*\)\s*;?\s*$/i,
+		);
+		const target = resolve(assignment?.[2] ?? call?.[2] ?? "");
+		if (target) return target;
+	}
+	return null;
+}
+
+function decodeBody(headers: HeaderReader, body: Uint8Array): string {
+	const declared = headers.get("content-type") ?? "";
+	const charset = declared.match(/charset\s*=\s*["']?([^;"'\s]+)/i)?.[1];
+	try {
+		return new TextDecoder(charset || "utf-8").decode(body);
+	} catch {
+		return new TextDecoder().decode(body);
+	}
+}
+
+function binarySignature(body: Uint8Array): "pdf" | "binary" | undefined {
+	const startsWith = (signature: number[]): boolean =>
+		body.length >= signature.length &&
+		signature.every((byte, index) => body[index] === byte);
+	if (startsWith([0x25, 0x50, 0x44, 0x46, 0x2d])) return "pdf";
+	for (const signature of [
+		[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+		[0xff, 0xd8, 0xff],
+		[0x47, 0x49, 0x46, 0x38],
+		[0x50, 0x4b, 0x03, 0x04],
+		[0x50, 0x4b, 0x05, 0x06],
+		[0x1f, 0x8b],
+		[0x7f, 0x45, 0x4c, 0x46],
+	]) {
+		if (startsWith(signature)) return "binary";
+	}
+	return undefined;
+}
+
+function looksBinary(headers: HeaderReader, body: Uint8Array): boolean {
+	if (body.length === 0) return false;
+	const sample = body.subarray(0, Math.min(body.length, 4096));
+	if (sample.includes(0)) return true;
+	const declared = headers.get("content-type") ?? "";
+	const charset = declared.match(/charset\s*=\s*["']?([^;"'\s]+)/i)?.[1];
+	let decoded: string;
+	try {
+		decoded = new TextDecoder(charset || "utf-8", { fatal: true }).decode(sample);
+	} catch {
+		return true;
+	}
+	let controls = 0;
+	for (const char of decoded) {
+		const code = char.codePointAt(0)!;
+		if ((code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d) || code === 0x7f) {
+			controls += 1;
+		}
+	}
+	return controls / Math.max(1, decoded.length) > 0.05;
+}
+
+function contentTypeOf(headers: HeaderReader, text: string): string {
+	const declared = headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+	if (declared) return declared;
+	const sample = text.trimStart().slice(0, 100).toLowerCase();
+	if (sample.startsWith("<!doctype html") || sample.startsWith("<html")) return "text/html";
+	if (sample.startsWith("{") || sample.startsWith("[")) return "application/json";
+	return "text/plain";
+}
+
+function isJson(contentType: string, text: string): boolean {
+	return (
+		contentType === "application/json" ||
+		contentType === "text/json" ||
+		contentType.endsWith("+json") ||
+		text.trimStart().startsWith("{") ||
+		text.trimStart().startsWith("[")
+	);
+}
+
+function isHtml(contentType: string): boolean {
+	return contentType === "text/html" || contentType === "application/xhtml+xml";
+}
+
+function isText(contentType: string): boolean {
+	return (
+		contentType.startsWith("text/") ||
+		contentType.includes("json") ||
+		contentType.includes("xml") ||
+		contentType === "application/javascript"
+	);
+}
+
+function textFromHtml(html: string): string {
+	const { document } = parseHTML(html);
+	return (document.body?.textContent || document.documentElement?.textContent || "")
+		.replace(/\r/g, "")
+		.replace(/[^\S\n]+/g, " ")
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.join("\n");
+}
+
+function fallbackHtmlContent(
+	html: string,
+	format: StaticWebFetchFormat,
+	removeImages: boolean,
+): ExtractedContent {
+	const { document } = parseHTML(html);
+	document.querySelectorAll("script,style,noscript,template,nav,footer,header").forEach((node) => node.remove());
+	if (removeImages) document.querySelectorAll("img,picture,figure").forEach((node) => node.remove());
+	const main = document.querySelector("main,article") ?? document.body;
+	const title =
+		document.querySelector('meta[property="og:title"]')?.getAttribute("content")?.trim() ??
+		document.querySelector("title")?.textContent?.trim() ??
+		document.querySelector("h1")?.textContent?.trim() ??
+		"";
+	const raw = main?.outerHTML ?? "";
+	const plain = textFromHtml(raw);
+	return {
+		content: format === "html" ? raw : plain,
+		title,
+		wordCount: plain ? plain.split(/\s+/).length : 0,
+	};
+}
+
+const denyExtractionNetwork: typeof globalThis.fetch = async () => {
+	throw new Error("Network access is disabled in the static extraction entrypoint");
+};
+
+async function extractHtml(
+	html: string,
+	url: string,
+	format: StaticWebFetchFormat,
+	options: StaticWebFetchOptions,
+	signal: AbortSignal,
+): Promise<ExtractedContent> {
+	throwIfAborted(signal);
+	const markdown = format === "markdown";
+	try {
+		const { document } = parseHTML(html);
+		const result = await raceWithAbort(
+			Defuddle(document as unknown as Document, url, {
+				markdown,
+				removeImages: options.removeImages ?? false,
+				includeReplies: options.includeReplies ?? "extractors",
+				useAsync: false,
+				fetch: denyExtractionNetwork,
+			}),
+			signal,
+		);
+		let content = result.content ?? "";
+		if (format === "text" && content) content = textFromHtml(content);
+		if (content.trim()) {
+			return {
+				content,
+				title: result.title,
+				author: result.author,
+				published: result.published,
+				site: result.site || result.domain,
+				language: result.language,
+				description: result.description,
+				wordCount: result.wordCount,
+			};
+		}
+	} catch (error) {
+		if (signal.aborted) throw abortException(signal);
+		// The DOM fallback below keeps extraction usable when Defuddle rejects.
+	}
+	return fallbackHtmlContent(html, format, options.removeImages ?? false);
+}
+
+async function extractPdf(
+	body: Uint8Array,
+	url: string,
+	format: StaticWebFetchFormat,
+	signal: AbortSignal,
+	loadParser: () => Promise<PdfParseCtor>,
+): Promise<ExtractedContent> {
+	if (format === "raw" || format === "json" || format === "html") {
+		throw new StaticFetchException(
+			"binary_content",
+			`PDF responses support markdown or text output, not ${format}`,
+			{ phase: "processing", finalUrl: url },
+		);
+	}
+	const PdfParse = await raceWithAbort(loadParser(), signal);
+	const parser = new PdfParse({ data: body });
+	try {
+		await raceWithAbort(parser.load(), signal);
+		const parsed = await raceWithAbort(parser.getText(), signal);
+		if (!parsed.text?.trim()) {
+			throw new StaticFetchException("no_content", "No text was extracted from the PDF", {
+				phase: "processing",
+				finalUrl: url,
+			});
+		}
+		let title = "Document";
+		try {
+			title = new URL(url).pathname.split("/").filter(Boolean).pop() || title;
+		} catch {
+			// URL validation already ran; keep the fallback title.
+		}
+		return {
+			content:
+				format === "markdown"
+					? `## PDF Content (${parsed.total} pages)\n\n${parsed.text}`
+					: parsed.text,
+			title,
+			wordCount: parsed.text.trim().split(/\s+/).length,
+		};
+	} finally {
+		await boundedCleanup(() => parser.destroy(), signal);
+	}
+}
+
+async function download(
+	url: string,
+	options: StaticWebFetchOptions,
+	dependencies: StaticWebFetchDependencies,
+	signal: AbortSignal,
+	limits: {
+		timeoutMs: number;
+		maxResponseBytes: number;
+		maxRedirects: number;
+		maxRetries: number;
+	},
+): Promise<DownloadedResponse> {
+	let current = parseHttpUrl(url).href;
+	let headers: Record<string, string> = {
+		Accept:
+			options.format === "raw"
+				? "text/html,application/xhtml+xml,application/json,application/xml;q=0.9,text/markdown;q=0.8,text/plain;q=0.8,*/*;q=0.7"
+				: "text/html,application/xhtml+xml,application/xml;q=0.9,text/markdown;q=0.8,*/*;q=0.7",
+		"Accept-Language": "en-US,en;q=0.9",
+		...options.headers,
+	};
+	const redirects: string[] = [];
+	const seen = new Set([current]);
+	const byteBudget: ByteBudget = {
+		remaining: limits.maxResponseBytes,
+		total: 0,
+	};
+	let proxy: URL | undefined;
+	let proxyPins: string[] = [];
+	if (options.proxy) {
+		try {
+			proxy = new URL(options.proxy);
+		} catch {
+			throw new StaticFetchException("invalid_url", "Invalid proxy URL", {
+				phase: "validation",
+			});
+		}
+		if (!["http:", "https:", "socks5:", "socks5h:"].includes(proxy.protocol)) {
+			throw new StaticFetchException(
+				"unsupported_protocol",
+				`Proxy must use http, https, socks5, or socks5h, got ${proxy.protocol}`,
+				{ phase: "validation" },
+			);
+		}
+		const proxyVerdict = await raceWithAbort(dependencies.validateUrl(proxy.href), signal);
+		if (proxyVerdict.dangerous) {
+			throw new StaticFetchException(
+				proxyVerdict.reason === "dns-error" || proxyVerdict.reason === "dns-empty"
+					? "dns_error"
+					: "blocked_ssrf",
+				`Proxy destination was blocked (${proxyVerdict.reason ?? "unsafe destination"})`,
+				{ phase: "validation" },
+			);
+		}
+		requireHostnamePins(proxy, proxyVerdict, "proxy");
+		proxyPins = proxyVerdict.pinnedIps;
+	}
+
+	while (true) {
+		throwIfAborted(signal);
+		const secret = scanForSecrets(current);
+		if (secret.found) {
+			throw new StaticFetchException(
+				"blocked_secret",
+				`Request URL contains potential secret material (${secret.matches.join(", ")})`,
+				{ phase: "validation", finalUrl: current, redirects },
+			);
+		}
+		const parsed = parseHttpUrl(current);
+		const verdict = await raceWithAbort(dependencies.validateUrl(current), signal);
+		if (verdict.dangerous) {
+			throw new StaticFetchException(
+				verdict.reason === "dns-error" || verdict.reason === "dns-empty"
+					? "dns_error"
+					: "blocked_ssrf",
+				`Request destination was blocked (${verdict.reason ?? "unsafe destination"})`,
+				{ phase: "validation", finalUrl: current, redirects },
+			);
+		}
+		requireHostnamePins(parsed, verdict, "request");
+
+		let nextUrl: string | null = null;
+		for (let attempt = 0; attempt <= limits.maxRetries; attempt++) {
+			throwIfAborted(signal);
+			const resolve = {
+				...resolveMap(parsed, verdict.pinnedIps),
+				...(proxy ? resolveMap(proxy, proxyPins) : undefined),
+			};
+			const transportPromise = dependencies.createTransport({
+				browser: options.browser ?? DEFAULT_WEBFETCH_BROWSER,
+				os: options.os ?? DEFAULT_WEBFETCH_OS,
+				proxy: options.proxy,
+				...(Object.keys(resolve).length > 0 ? { resolve } : {}),
+			});
+			// If cancellation wins before creation finishes, close the late transport
+			// instead of dropping a native connection pool with no owner.
+			transportPromise.then(
+				(transport) => {
+					if (signal.aborted) transport.close().catch(() => {});
+				},
+				() => {},
+			);
+			const transport = await raceWithAbort(transportPromise, signal);
+			let retryMs: number | undefined;
+			try {
+				const requestPromise = dependencies.request(current, {
+					redirect: "manual",
+					headers,
+					signal,
+					timeout: limits.timeoutMs,
+					transport,
+				});
+				// A custom or defective transport may ignore AbortSignal. Dispose of a
+				// response that arrives after the caller has already stopped waiting.
+				requestPromise.then(
+					(response) => {
+						if (signal.aborted) safeCancel(response.body);
+					},
+					() => {},
+				);
+				const response = await raceWithAbort(requestPromise, signal);
+
+				if (RETRYABLE_STATUS.has(response.status) && attempt < limits.maxRetries) {
+					safeCancel(response.body);
+					throw new RetryAttempt(retryDelay(attempt));
+				}
+
+				const target = redirectTarget(response, current);
+				if (target) {
+					safeCancel(response.body);
+					if (redirects.length >= limits.maxRedirects) {
+						throw new StaticFetchException(
+							"too_many_redirects",
+							`Redirect limit (${limits.maxRedirects}) exceeded`,
+							{ phase: "loading", finalUrl: current, redirects },
+						);
+					}
+					const normalizedTarget = parseHttpUrl(target, "redirect URL").href;
+					if (seen.has(normalizedTarget)) {
+						throw new StaticFetchException("redirect_loop", "Redirect loop detected", {
+							phase: "loading",
+							finalUrl: normalizedTarget,
+							redirects,
+						});
+					}
+					if (new URL(current).origin !== new URL(normalizedTarget).origin) {
+						headers = headersForCrossOriginRedirect(headers);
+					}
+					redirects.push(normalizedTarget);
+					seen.add(normalizedTarget);
+					nextUrl = normalizedTarget;
+					break;
+				}
+
+				const body = await readBody(response, byteBudget, signal);
+				const responseUrl = response.url ?? current;
+				const responseText = decodeBody(response.headers, body.body);
+				const responseType = contentTypeOf(response.headers, responseText);
+				const clientTarget =
+					response.status >= 200 && response.status < 300 && isHtml(responseType)
+						? clientRedirectTarget(responseText, responseUrl)
+						: null;
+				if (clientTarget) {
+					if (redirects.length >= limits.maxRedirects) {
+						throw new StaticFetchException(
+							"too_many_redirects",
+							`Redirect limit (${limits.maxRedirects}) exceeded`,
+							{ phase: "loading", finalUrl: responseUrl, redirects },
+						);
+					}
+					const normalizedTarget = parseHttpUrl(clientTarget, "redirect URL").href;
+					if (seen.has(normalizedTarget)) {
+						throw new StaticFetchException("redirect_loop", "Redirect loop detected", {
+							phase: "loading",
+							finalUrl: normalizedTarget,
+							redirects,
+						});
+					}
+					if (new URL(current).origin !== new URL(normalizedTarget).origin) {
+						headers = headersForCrossOriginRedirect(headers);
+					}
+					redirects.push(normalizedTarget);
+					seen.add(normalizedTarget);
+					nextUrl = normalizedTarget;
+					break;
+				}
+				return {
+					url: responseUrl,
+					status: response.status,
+					statusText: response.statusText ?? "",
+					headers: response.headers,
+					body: body.body,
+					downloadedBytes: byteBudget.total,
+					contentLength: body.contentLength,
+					redirects,
+				};
+			} catch (error) {
+				if (signal.aborted) throw abortException(signal);
+				if (error instanceof RetryAttempt) retryMs = error.delayMs;
+				else if (attempt < limits.maxRetries && isRetryableNetworkError(error)) {
+					retryMs = retryDelay(attempt);
+				} else throw error;
+			} finally {
+				await boundedCleanup(() => transport.close(), signal);
+			}
+			if (retryMs !== undefined) {
+				await raceWithAbort(dependencies.sleep(retryMs), signal);
+				continue;
+			}
+		}
+		if (!nextUrl) {
+			throw new StaticFetchException("network_error", "Request failed after retries", {
+				phase: "connecting",
+				finalUrl: current,
+				redirects,
+				retryable: true,
+			});
+		}
+		current = nextUrl;
+	}
+}
+
+function redactCredentialPairs(value: string): string {
+	return value.replace(
+		/(^|[?&#;])([^?&#;=]+)=([^&#;\s]*)/g,
+		(match, separator: string, rawName: string) => {
+			let name = rawName;
+			try {
+				name = decodeURIComponent(rawName);
+			} catch {
+				// Keep the encoded name for the credential-key check.
+			}
+			return CREDENTIAL_PARAMETER.test(name)
+				? `${separator}${rawName}=[REDACTED]`
+				: match;
+		},
+	);
+}
+
+function redactUrl(value: unknown): string {
+	const text = typeof value === "string" ? value : String(value);
+	try {
+		const parsed = new URL(text);
+		if (parsed.username) parsed.username = "[REDACTED]";
+		if (parsed.password) parsed.password = "[REDACTED]";
+		for (const name of [...parsed.searchParams.keys()]) {
+			let decoded = name;
+			try {
+				decoded = decodeURIComponent(name);
+			} catch {
+				// URLSearchParams already decoded ordinary names.
+			}
+			if (CREDENTIAL_PARAMETER.test(decoded)) {
+				parsed.searchParams.set(name, "[REDACTED]");
+			}
+		}
+		if (parsed.hash) parsed.hash = redactCredentialPairs(parsed.hash.slice(1));
+		return redactSecrets(redactCredentialPairs(parsed.href));
+	} catch {
+		return redactSecrets(redactCredentialPairs(text));
+	}
+}
+
+function redactErrorText(value: unknown): string {
+	const text = typeof value === "string" ? value : String(value);
+	const urlsRedacted = text.replace(
+		/https?:\/\/[^\s<>"']+/gi,
+		(candidate) => redactUrl(candidate),
+	);
+	return redactSecrets(redactCredentialPairs(urlsRedacted));
+}
+
+function failureResult(
+	url: string,
+	startedAt: number,
+	error: unknown,
+): StaticWebFetchFailure {
+	if (error instanceof StaticFetchException) {
+		return {
+			ok: false,
+			url: redactUrl(url),
+			finalUrl: error.finalUrl ? redactUrl(error.finalUrl) : undefined,
+			redirects: error.redirects.map((redirect) => redactUrl(redirect)),
+			elapsedMs: Date.now() - startedAt,
+			error: {
+				code: error.code,
+				message: error.message,
+				phase: error.phase,
+				retryable: error.retryable,
+				statusCode: error.statusCode,
+			},
+		};
+	}
+	const value = error as NodeJS.ErrnoException | undefined;
+	const message = redactErrorText(value?.message ?? String(error));
+	const timedOut = value?.code === "ETIMEDOUT" || /timed out/i.test(message);
+	return {
+		ok: false,
+		url: redactUrl(url),
+		redirects: [],
+		elapsedMs: Date.now() - startedAt,
+		error: {
+			code: timedOut ? "timeout" : "network_error",
+			message,
+			phase: timedOut ? "waiting" : "connecting",
+			retryable: true,
+		},
+	};
+}
+
+export function createStaticWebFetcher(
+	overrides: Partial<StaticWebFetchDependencies> = {},
+): (url: string, options?: StaticWebFetchOptions) => Promise<StaticWebFetchResult> {
+	const dependencies: StaticWebFetchDependencies = {
+		...defaultDependencies,
+		...overrides,
+	};
+	return async (url, options = {}) => {
+		const startedAt = Date.now();
+		let timeout: ReturnType<typeof requestSignal> | undefined;
+		try {
+			if (typeof url !== "string") {
+				throw new StaticFetchException("invalid_url", "URL must be a string", {
+					phase: "validation",
+				});
+			}
+			validateRuntimeOptions(options);
+			parseHttpUrl(url);
+			const timeoutMs = numericOption(
+				options.timeoutMs,
+				DEFAULT_WEBFETCH_TIMEOUT_MS,
+				"timeoutMs",
+				1,
+				120_000,
+			);
+			const maxChars = numericOption(
+				options.maxChars,
+				DEFAULT_MAX_OUTPUT_CHARS,
+				"maxChars",
+				1,
+				DEFAULT_MAX_RESPONSE_BYTES,
+			);
+			const maxResponseBytes = numericOption(
+				options.maxResponseBytes,
+				DEFAULT_MAX_RESPONSE_BYTES,
+				"maxResponseBytes",
+				1,
+				DEFAULT_MAX_RESPONSE_BYTES,
+			);
+			const maxRedirects = numericOption(
+				options.maxRedirects,
+				DEFAULT_MAX_REDIRECTS,
+				"maxRedirects",
+				0,
+				20,
+			);
+			const maxRetries = numericOption(
+				options.maxRetries,
+				DEFAULT_MAX_RETRIES,
+				"maxRetries",
+				0,
+				5,
+			);
+			timeout = requestSignal(options.signal, timeoutMs);
+			throwIfAborted(timeout.signal);
+			const downloaded = await download(
+				url,
+				options,
+				dependencies,
+				timeout.signal,
+				{ timeoutMs, maxResponseBytes, maxRedirects, maxRetries },
+			);
+			const format = options.format ?? "markdown";
+			return await createResult(
+				url,
+				downloaded,
+				options,
+				dependencies,
+				format,
+				maxChars,
+				timeout.signal,
+				startedAt,
+			);
+		} catch (error) {
+			return failureResult(url, startedAt, error);
+		} finally {
+			timeout?.dispose();
+		}
+	};
+}
+
+async function createResult(
+	originalUrl: string,
+	downloaded: DownloadedResponse,
+	options: StaticWebFetchOptions,
+	dependencies: StaticWebFetchDependencies,
+	format: StaticWebFetchFormat,
+	maxChars: number,
+	signal: AbortSignal,
+	startedAt: number,
+): Promise<StaticWebFetchSuccess> {
+	const declaredType =
+		downloaded.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+	const signature = binarySignature(downloaded.body);
+	if (
+		signature === "binary" ||
+		(signature !== "pdf" &&
+			declaredType !== "application/pdf" &&
+			looksBinary(downloaded.headers, downloaded.body))
+	) {
+		throw new StaticFetchException("binary_content", "The response body is binary", {
+			phase: "processing",
+			finalUrl: downloaded.url,
+			redirects: downloaded.redirects,
+		});
+	}
+	const text = signature === "pdf" ? "" : decodeBody(downloaded.headers, downloaded.body);
+	const contentType =
+		signature === "pdf" ? "application/pdf" : contentTypeOf(downloaded.headers, text);
+	if (downloaded.status < 200 || downloaded.status >= 300) {
+		throw new StaticFetchException(
+			"http_error",
+			`Server returned HTTP ${downloaded.status}${downloaded.statusText ? ` ${downloaded.statusText}` : ""}`,
+			{
+				phase: "loading",
+				statusCode: downloaded.status,
+				finalUrl: downloaded.url,
+				redirects: downloaded.redirects,
+				retryable: RETRYABLE_STATUS.has(downloaded.status),
+			},
+		);
+	}
+	let extracted: ExtractedContent;
+	if (contentType === "application/pdf") {
+		extracted = await extractPdf(
+			downloaded.body,
+			downloaded.url,
+			format,
+			signal,
+			dependencies.loadPdfParser,
+		);
+	} else if (!isText(contentType)) {
+		throw new StaticFetchException(
+			"binary_content",
+			`Unsupported binary response (${contentType || "unknown content type"})`,
+			{ phase: "processing", finalUrl: downloaded.url, redirects: downloaded.redirects },
+		);
+	} else if (format === "raw") {
+		extracted = { content: text };
+	} else if (format === "html" && !isHtml(contentType)) {
+		throw new StaticFetchException(
+			"unexpected_content_type",
+			`HTML output requires an HTML response, got ${contentType}`,
+			{ phase: "processing", finalUrl: downloaded.url, redirects: downloaded.redirects },
+		);
+	} else if (isJson(contentType, text)) {
+		let formatted: string;
+		try {
+			formatted = JSON.stringify(JSON.parse(text), null, 2);
+		} catch {
+			if (format === "json") {
+				throw new StaticFetchException("parse_error", "The response was not valid JSON", {
+					phase: "processing",
+					finalUrl: downloaded.url,
+					redirects: downloaded.redirects,
+				});
+			}
+			formatted = text;
+		}
+		extracted = {
+			content: format === "markdown" ? `\`\`\`json\n${formatted}\n\`\`\`` : formatted,
+		};
+	} else if (format === "json") {
+		throw new StaticFetchException("parse_error", "The response was not JSON", {
+			phase: "processing",
+			finalUrl: downloaded.url,
+			redirects: downloaded.redirects,
+		});
+	} else if (isHtml(contentType)) {
+		const bot = detectBotBlock(text);
+		if (bot.blocked) {
+			throw new StaticFetchException("bot_detected", bot.message, {
+				phase: "loading",
+				finalUrl: downloaded.url,
+				redirects: downloaded.redirects,
+				retryable: bot.retryable,
+			});
+		}
+		extracted = await extractHtml(text, downloaded.url, format, options, signal);
+	} else if (contentType.includes("xml")) {
+		extracted = {
+			content:
+				format === "text"
+					? textFromHtml(text)
+					: format === "markdown"
+						? `\`\`\`xml\n${text}\n\`\`\``
+						: text,
+		};
+	} else {
+		extracted = { content: text };
+	}
+
+	throwIfAborted(signal);
+	if (!extracted.content.trim()) {
+		throw new StaticFetchException(
+			"no_content",
+			"No readable content was extracted; use a browser renderer for JavaScript-only pages",
+			{ phase: "processing", finalUrl: downloaded.url, redirects: downloaded.redirects },
+		);
+	}
+	const fullContent = extracted.content;
+	const truncated = fullContent.length > maxChars;
+	const content = truncated ? fullContent.slice(0, maxChars) : fullContent;
+	let site = extracted.site ?? "";
+	if (!site) {
+		try {
+			site = new URL(downloaded.url).hostname;
+		} catch {
+			// URL validation already ran; keep the empty fallback.
+		}
+	}
+	const title = extracted.title ?? "";
+	const wordCount =
+		extracted.wordCount ??
+		(fullContent.trim() ? fullContent.trim().split(/\s+/).filter(Boolean).length : 0);
+	return {
+		ok: true,
+		kind: "content",
+		url: redactUrl(originalUrl),
+		finalUrl: redactUrl(downloaded.url),
+		redirects: downloaded.redirects.map((redirect) => redactUrl(redirect)),
+		statusCode: downloaded.status,
+		statusText: downloaded.statusText,
+		contentType,
+		format,
+		content,
+		truncated,
+		title,
+		author: extracted.author ?? "",
+		published: extracted.published ?? "",
+		site,
+		language: extracted.language ?? "",
+		description: extracted.description ?? "",
+		wordCount,
+		fullContentChars: fullContent.length,
+		outputChars: content.length,
+		browser: options.browser ?? DEFAULT_WEBFETCH_BROWSER,
+		os: options.os ?? DEFAULT_WEBFETCH_OS,
+		downloadedBytes: downloaded.downloadedBytes,
+		contentLength: downloaded.contentLength,
+		elapsedMs: Date.now() - startedAt,
+		browserEscalated: false,
+		remoteFallbackUsed: false,
+		persisted: false,
+		proxyUsed: options.proxy !== undefined,
+		targetPinning: options.proxy ? "proxy-dependent" : "local",
+	};
+}
+
+const defaultFetcher = createStaticWebFetcher();
+
+/**
+ * Fetch and locally extract one HTTP(S) URL without browser escalation,
+ * remote readers, tool registration, or persistent content storage.
+ */
+export function fetchPage(
+	url: string,
+	options?: StaticWebFetchOptions,
+): Promise<StaticWebFetchResult> {
+	return defaultFetcher(url, options);
+}
+
+/** Supported `pi-webaio/webfetch` shorthand. */
+export { fetchPage as fetch };

--- a/src/webfetch.ts
+++ b/src/webfetch.ts
@@ -1,0 +1,22 @@
+export {
+	DEFAULT_MAX_OUTPUT_CHARS,
+	DEFAULT_MAX_REDIRECTS,
+	DEFAULT_MAX_RESPONSE_BYTES,
+	DEFAULT_MAX_RETRIES,
+	DEFAULT_WEBFETCH_BROWSER,
+	DEFAULT_WEBFETCH_OS,
+	DEFAULT_WEBFETCH_TIMEOUT_MS,
+	fetch,
+	fetchPage,
+} from "./webfetch-api.ts";
+
+export type {
+	StaticWebFetchError,
+	StaticWebFetchErrorCode,
+	StaticWebFetchFailure,
+	StaticWebFetchFormat,
+	StaticWebFetchOptions,
+	StaticWebFetchReplyPolicy,
+	StaticWebFetchResult,
+	StaticWebFetchSuccess,
+} from "./webfetch-api.ts";

--- a/tests/perf-extraction.test.mjs
+++ b/tests/perf-extraction.test.mjs
@@ -235,12 +235,12 @@ test("a hanging Jina transport resolves to null within the timeout", async () =>
 
 // ─── P1: Defuddle timeout tightened ────────────────────────────────
 
-test("DEFUDDLE_TIMEOUT is tightened from the previous 8000ms", () => {
+test("DEFUDDLE_TIMEOUT matches the 3000ms extraction budget", () => {
 	assert.ok(
 		DEFUDDLE_TIMEOUT < 8000,
 		"Defuddle timeout should be tighter than the old 8s",
 	);
-	assert.strictEqual(DEFUDDLE_TIMEOUT, 4000);
+	assert.strictEqual(DEFUDDLE_TIMEOUT, 3000);
 });
 
 // ─── P1: Readability ratio heuristic ───────────────────────────────

--- a/tests/ssrf-hardening.test.mjs
+++ b/tests/ssrf-hardening.test.mjs
@@ -61,6 +61,19 @@ test("isCloudMetadataIp: IPv4-compatible ::169.254.169.254 is metadata", () => {
 	assert.equal(isCloudMetadataIp("::169.254.169.254"), true);
 });
 
+test("isCloudMetadataIp: transition encodings of metadata stay on the floor", () => {
+	for (const ip of [
+		"64:ff9b::a9fe:a9fe",
+		"64:ff9b:1:a9fe:a9:fe00::",
+		"64:ff9b:1:aba9:fe:a9fe::",
+		"64:ff9b:1:abcd:a9:fea9:fe00:0",
+		"2002:a9fe:a9fe::",
+		"2001:0:4136:e378:8000:63bf:5601:5601",
+	]) {
+		assert.equal(isCloudMetadataIp(ip), true, ip);
+	}
+});
+
 test("isCloudMetadataIp: public IP is not metadata", () => {
 	assert.equal(isCloudMetadataIp("8.8.8.8"), false);
 	assert.equal(isCloudMetadataIp("93.184.216.34"), false);
@@ -71,6 +84,157 @@ test("isCloudMetadataIp: other link-local IP is not metadata (floor is specific)
 	// floor must not over-match, or it would shadow the allow-list for the
 	// whole 169.254/16 range.
 	assert.equal(isCloudMetadataIp("169.254.1.1"), false);
+});
+
+// ─── Non-public address coverage ────────────────────────────────────
+
+for (const [label, url] of [
+	["IPv4 protocol-assignment range", "http://192.0.0.8/"],
+	["IPv4 documentation range TEST-NET-1", "http://192.0.2.1/"],
+	["IPv4 deprecated 6to4 relay range", "http://192.88.99.1/"],
+	["IPv4 6a44-relay anycast", "http://192.88.99.2/"],
+	["IPv4 documentation range TEST-NET-2", "http://198.51.100.1/"],
+	["IPv4 documentation range TEST-NET-3", "http://203.0.113.1/"],
+	["IPv4 multicast", "http://224.0.0.1/"],
+	["IPv4 reserved", "http://240.0.0.1/"],
+	["IPv6 local-use translation prefix", "http://[64:ff9b:1::808:808]/"],
+	["IPv6 translation of private IPv4", "http://[64:ff9b::a00:1]/"],
+	["IPv6 dummy prefix", "http://[100:0:0:1::1]/"],
+	["6to4 with compressed private IPv4 payload", "http://[2002:a00:1::]/"],
+	[
+		"Teredo with compressed private IPv4 payload",
+		"http://[2001:0:4136:e378:8000:63bf:f5ff:fffe]/",
+	],
+	["IPv6 benchmarking", "http://[2001:2::1]/"],
+	["IPv6 deprecated ORCHID", "http://[2001:10::1]/"],
+	["IPv6 documentation", "http://[2001:db8::1]/"],
+	["IPv6 documentation (3fff::/20)", "http://[3fff::1]/"],
+	["IPv6 segment-routing SIDs", "http://[5f00::1]/"],
+	["IPv6 link-local outside fe80::/16", "http://[febf::1]/"],
+	["IPv6 multicast", "http://[ff02::1]/"],
+]) {
+	test(`non-public ranges: ${label} is blocked`, async () => {
+		setSsrfAllowRangesForTest([]);
+		const r = await validateUrlForSsrf(url);
+		assert.equal(r.dangerous, true);
+		assert.equal(r.reason, "private-range");
+		assert.deepEqual(r.pinnedIps, []);
+	});
+}
+
+for (const [label, url] of [
+	["IPv4 PCP anycast exception", "http://192.0.0.9/"],
+	["IPv4 TURN anycast exception", "http://192.0.0.10/"],
+	["IPv4 address before protocol assignments", "http://191.255.255.255/"],
+	["IPv4 address after protocol assignments", "http://192.0.1.1/"],
+	["IPv4 address before benchmarking", "http://198.17.255.255/"],
+	["IPv4 address after benchmarking", "http://198.20.0.1/"],
+	["IPv4 unicast below multicast", "http://223.255.255.255/"],
+	["IPv6 well-known translation of public IPv4", "http://[64:ff9b::808:808]/"],
+	["6to4 with compressed public IPv4 payload", "http://[2002:808:808::]/"],
+	[
+		"Teredo with compressed public IPv4 payload",
+		"http://[2001:0:4136:e378:8000:63bf:f7f7:f7f7]/",
+	],
+	["IPv6 PCP anycast exception", "http://[2001:1::1]/"],
+	["IPv6 TURN anycast exception", "http://[2001:1::2]/"],
+	["IPv6 DNS-SD anycast exception", "http://[2001:1::3]/"],
+	["IPv6 AMT exception", "http://[2001:3::1]/"],
+	["IPv6 AS112 exception", "http://[2001:4:112::1]/"],
+	["IPv6 ORCHIDv2 first block", "http://[2001:20::1]/"],
+	["IPv6 ORCHIDv2 final block", "http://[2001:2f:ffff::1]/"],
+	["IPv6 Drone Remote ID first block", "http://[2001:30::1]/"],
+	["IPv6 Drone Remote ID final block", "http://[2001:3f:ffff::1]/"],
+	["IPv6 address after 3fff::/20 documentation", "http://[3fff:1000::1]/"],
+	["IPv6 address after 5f00::/16 SRv6 SIDs", "http://[5f01::1]/"],
+]) {
+	test(`public range exceptions: ${label} is allowed`, async () => {
+		setSsrfAllowRangesForTest([]);
+		const r = await validateUrlForSsrf(url);
+		assert.equal(r.dangerous, false);
+		assert.ok(r.pinnedIps.length > 0);
+	});
+}
+
+test("non-public ranges: expanded IPv6 documentation spelling is blocked", async () => {
+	setSsrfAllowRangesForTest([]);
+	const r = await validateUrlForSsrf(
+		"http://[2001:0db8:0000:0000:0000:0000:0000:0001]/",
+	);
+	assert.equal(r.dangerous, true);
+});
+
+test("non-public ranges: IPv4-mapped documentation address is blocked", async () => {
+	setSsrfAllowRangesForTest([]);
+	const r = await validateUrlForSsrf("http://[::ffff:192.0.2.1]/");
+	assert.equal(r.dangerous, true);
+});
+
+test("non-public ranges: canonical IPv4-compatible private forms are blocked", async () => {
+	setSsrfAllowRangesForTest([]);
+	for (const url of ["http://[::127.0.0.1]/", "http://[::10.0.0.1]/"]) {
+		const r = await validateUrlForSsrf(url);
+		assert.equal(r.dangerous, true, url);
+		assert.equal(r.reason, "private-range", url);
+	}
+});
+
+test("non-public ranges: mask boundaries classify both sides", async () => {
+	setSsrfAllowRangesForTest([]);
+	for (const url of [
+		"http://[100:0:0:1:ffff:ffff:ffff:ffff]/",
+		"http://[2001:1f:ffff:ffff:ffff:ffff:ffff:ffff]/",
+		"http://[3fff:fff:ffff:ffff:ffff:ffff:ffff:ffff]/",
+		"http://[5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff]/",
+	]) {
+		assert.equal((await validateUrlForSsrf(url)).dangerous, true, url);
+	}
+	for (const url of [
+		"http://[100:0:0:2::1]/",
+		"http://[3fff:1000::1]/",
+		"http://[5f01::1]/",
+	]) {
+		assert.equal((await validateUrlForSsrf(url)).dangerous, false, url);
+	}
+});
+
+test("non-public ranges: exact IPv6 exception boundaries do not widen", async () => {
+	setSsrfAllowRangesForTest([]);
+	for (const url of [
+		"http://[2001:1::4]/",
+		"http://[2001:2:ffff::1]/",
+		"http://[2001:4:111::1]/",
+		"http://[2001:4:113::1]/",
+	]) {
+		assert.equal((await validateUrlForSsrf(url)).dangerous, true, url);
+	}
+});
+
+test("non-public ranges: mixed DNS answer with documentation address is blocked", async () => {
+	setSsrfAllowRangesForTest([]);
+	const r = await validateUrlForSsrf(
+		"http://mixed.example/",
+		resolverReturning(["93.184.216.34", "203.0.113.1"]),
+	);
+	assert.equal(r.dangerous, true);
+	assert.deepEqual(r.pinnedIps, []);
+});
+
+test("non-public ranges: explicit CIDR allow-list permits configured ranges and compatible forms", async () => {
+	setSsrfAllowRangesForTest(
+		parseAllowRanges("10.0.0.0/8,203.0.113.0/24,3fff::/20"),
+	);
+	try {
+		for (const url of [
+			"http://203.0.113.1/",
+			"http://[3fff::1]/",
+			"http://[::10.0.0.1]/",
+		]) {
+			assert.equal((await validateUrlForSsrf(url)).dangerous, false, url);
+		}
+	} finally {
+		setSsrfAllowRangesForTest(null);
+	}
 });
 
 // ─── Metadata floor is non-overridable by the allow-list ────────────
@@ -117,6 +281,27 @@ test("metadata floor: resolved 169.254.169.254 blocked even when 169.254.0.0/16 
 		);
 		assert.equal(r.dangerous, true, "resolved metadata IP must hit the floor");
 		assert.equal(r.reason, "cloud-metadata");
+	} finally {
+		setSsrfAllowRangesForTest(null);
+	}
+});
+
+test("metadata floor: transition encodings stay blocked when their outer ranges are allowed", async () => {
+	setSsrfAllowRangesForTest(
+		parseAllowRanges("64:ff9b::/32,2002::/16,2001::/32"),
+	);
+	try {
+		for (const url of [
+			"http://[64:ff9b::a9fe:a9fe]/",
+			"http://[64:ff9b:1:a9fe:a9:fe00::]/",
+			"http://[64:ff9b:1:aba9:fe:a9fe::]/",
+			"http://[2002:a9fe:a9fe::]/",
+			"http://[2001:0:4136:e378:8000:63bf:5601:5601]/",
+		]) {
+			const r = await validateUrlForSsrf(url);
+			assert.equal(r.dangerous, true, url);
+			assert.equal(r.reason, "cloud-metadata", url);
+		}
 	} finally {
 		setSsrfAllowRangesForTest(null);
 	}

--- a/tests/static-webfetch-api.test.mjs
+++ b/tests/static-webfetch-api.test.mjs
@@ -1,0 +1,990 @@
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+	createStaticWebFetcher,
+	DEFAULT_MAX_RESPONSE_BYTES,
+} from "../src/webfetch-api.ts";
+
+const encoder = new TextEncoder();
+
+function response({
+	url = "https://example.test/",
+	status = 200,
+	statusText = status === 200 ? "OK" : "",
+	headers = {},
+	body = "",
+} = {}) {
+	const bytes = typeof body === "string" ? encoder.encode(body) : body;
+	return {
+		url,
+		status,
+		statusText,
+		ok: status >= 200 && status < 300,
+		headers: new Headers(headers),
+		body: new ReadableStream({
+			start(controller) {
+				controller.enqueue(bytes);
+				controller.close();
+			},
+		}),
+	};
+}
+
+function runtime(overrides = {}) {
+	const calls = {
+		validated: [],
+		transports: [],
+		requests: [],
+		closed: 0,
+		sleeps: [],
+	};
+	const dependencies = {
+		validateUrl: async (url) => {
+			calls.validated.push(url);
+			return { dangerous: false, pinnedIps: ["93.184.216.34"] };
+		},
+		createTransport: async (options) => {
+			calls.transports.push(options);
+			return {
+				async close() {
+					calls.closed += 1;
+				},
+			};
+		},
+		request: async (url, init) => {
+			calls.requests.push({ url, init });
+			return response({
+				url,
+				headers: { "content-type": "text/plain" },
+				body: "ok",
+			});
+		},
+		sleep: async (ms) => {
+			calls.sleeps.push(ms);
+		},
+		...overrides,
+	};
+	return { fetchPage: createStaticWebFetcher(dependencies), calls };
+}
+
+test("rejects unsupported protocols before validation or transport", async () => {
+	const { fetchPage, calls } = runtime();
+	const result = await fetchPage("file:///etc/passwd");
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "unsupported_protocol");
+	assert.deepEqual(calls.validated, []);
+	assert.deepEqual(calls.transports, []);
+});
+
+test("blocks an SSRF verdict before opening a transport", async () => {
+	const { fetchPage, calls } = runtime({
+		validateUrl: async (url) => {
+			calls.validated.push(url);
+			return { dangerous: true, reason: "private-range", pinnedIps: [] };
+		},
+	});
+	const result = await fetchPage("http://127.0.0.1/");
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "blocked_ssrf");
+	assert.deepEqual(calls.transports, []);
+});
+
+test("fails closed when a hostname has no validated DNS pins", async () => {
+	const { fetchPage, calls } = runtime({
+		validateUrl: async (url) => {
+			calls.validated.push(url);
+			return { dangerous: false, pinnedIps: [] };
+		},
+	});
+	const result = await fetchPage("https://example.test/");
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "dns_error");
+	assert.deepEqual(calls.transports, []);
+});
+
+test("validates and DNS-pins every redirect hop", async () => {
+	const responses = [
+		response({
+			url: "https://a.example/start",
+			status: 302,
+			headers: { location: "https://b.example/final" },
+		}),
+		response({
+			url: "https://b.example/final",
+			headers: { "content-type": "text/plain" },
+			body: "redirected",
+		}),
+	];
+	const pins = {
+		"https://a.example/start": ["203.0.113.10"],
+		"https://b.example/final": ["203.0.113.11"],
+	};
+	const { fetchPage, calls } = runtime({
+		validateUrl: async (url) => {
+			calls.validated.push(url);
+			return { dangerous: false, pinnedIps: pins[url] };
+		},
+		request: async (url, init) => {
+			calls.requests.push({ url, init });
+			return responses.shift();
+		},
+	});
+	const result = await fetchPage("https://a.example/start", {
+		format: "raw",
+		headers: {
+			Authorization: "Bearer test-token",
+			Cookie: "sid=secret",
+			"X-API-Key": "redirect-secret",
+			"X-Trace": "drop",
+			"User-Agent": "Static fetch test",
+		},
+	});
+
+	assert.equal(result.ok, true);
+	assert.equal(result.finalUrl, "https://b.example/final");
+	assert.equal(result.content, "redirected");
+	assert.deepEqual(result.redirects, ["https://b.example/final"]);
+	assert.deepEqual(calls.validated, [
+		"https://a.example/start",
+		"https://b.example/final",
+	]);
+	assert.deepEqual(calls.transports[0].resolve, {
+		"a.example": ["203.0.113.10"],
+	});
+	assert.deepEqual(calls.transports[1].resolve, {
+		"b.example": ["203.0.113.11"],
+	});
+	assert.equal(calls.requests[0].init.redirect, "manual");
+	assert.equal(calls.requests[1].init.headers.Authorization, undefined);
+	assert.equal(calls.requests[1].init.headers.Cookie, undefined);
+	assert.equal(calls.requests[1].init.headers["X-API-Key"], undefined);
+	assert.equal(calls.requests[1].init.headers["X-Trace"], undefined);
+	assert.equal(calls.requests[1].init.headers["User-Agent"], "Static fetch test");
+	assert.equal(calls.closed, 2);
+});
+
+test("detects a client-side redirect loop without issuing a repeated request", async () => {
+	const start = "https://example.test/start";
+	const final = "https://example.test/final";
+	const responses = [
+		response({
+			url: start,
+			headers: { "content-type": "text/html" },
+			body: '<meta http-equiv="refresh" content="0; url=/final">',
+		}),
+		response({
+			url: final,
+			headers: { "content-type": "text/html" },
+			body: '<script>location.replace("/start")</script>',
+		}),
+	];
+	const { fetchPage, calls } = runtime({
+		request: async (url, init) => {
+			calls.requests.push({ url, init });
+			return responses.shift();
+		},
+	});
+	const result = await fetchPage(start, { format: "raw" });
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "redirect_loop");
+	assert.equal(calls.requests.length, 2);
+});
+
+test("blocks a redirect target before issuing the second request", async () => {
+	const { fetchPage, calls } = runtime({
+		validateUrl: async (url) => {
+			calls.validated.push(url);
+			return url.includes("127.0.0.1")
+				? { dangerous: true, reason: "private-range", pinnedIps: [] }
+				: { dangerous: false, pinnedIps: ["93.184.216.34"] };
+		},
+		request: async (url, init) => {
+			calls.requests.push({ url, init });
+			return response({
+				url,
+				status: 302,
+				headers: { location: "http://127.0.0.1/admin" },
+			});
+		},
+	});
+	const result = await fetchPage("https://example.test/");
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "blocked_ssrf");
+	assert.equal(calls.requests.length, 1);
+});
+
+test("follows a literal client-side redirect through the same guard", async () => {
+	const first = "https://example.test/start";
+	const second = "https://example.test/final";
+	const responses = [
+		response({
+			url: first,
+			headers: { "content-type": "text/html" },
+			body: '<meta http-equiv="refresh" content="0; url=/final">',
+		}),
+		response({
+			url: second,
+			headers: { "content-type": "text/plain" },
+			body: "done",
+		}),
+	];
+	const { fetchPage, calls } = runtime({
+		request: async (url, init) => {
+			calls.requests.push({ url, init });
+			return responses.shift();
+		},
+	});
+	const result = await fetchPage(first, { format: "raw" });
+	assert.equal(result.ok, true);
+	assert.equal(result.finalUrl, second);
+	assert.deepEqual(calls.validated, [first, second]);
+});
+
+test("drops custom headers across a client-side cross-origin redirect", async () => {
+	const responses = [
+		response({
+			url: "https://a.example/start",
+			headers: { "content-type": "text/html" },
+			body: '<meta http-equiv="refresh" content="0; url=https://b.example/final">',
+		}),
+		response({
+			url: "https://b.example/final",
+			headers: { "content-type": "text/plain" },
+			body: "done",
+		}),
+	];
+	const { fetchPage, calls } = runtime({
+		request: async (url, init) => {
+			calls.requests.push({ url, init });
+			return responses.shift();
+		},
+	});
+	const result = await fetchPage("https://a.example/start", {
+		format: "raw",
+		headers: { "X-API-Key": "do-not-forward", "X-Trace": "drop" },
+	});
+	assert.equal(result.ok, true);
+	assert.equal(calls.requests[1].init.headers["X-API-Key"], undefined);
+	assert.equal(calls.requests[1].init.headers["X-Trace"], undefined);
+});
+
+test("validates and pins an explicit proxy separately from the target", async () => {
+	const { fetchPage, calls } = runtime({
+		validateUrl: async (url) => {
+			calls.validated.push(url);
+			return {
+				dangerous: false,
+				pinnedIps: [url.includes("proxy") ? "203.0.113.20" : "203.0.113.10"],
+			};
+		},
+	});
+	const result = await fetchPage("https://example.test/", {
+		format: "raw",
+		proxy: "http://proxy.example:8080/",
+	});
+	assert.equal(result.ok, true);
+	assert.equal(result.proxyUsed, true);
+	assert.equal(result.targetPinning, "proxy-dependent");
+	assert.deepEqual(calls.validated, [
+		"http://proxy.example:8080/",
+		"https://example.test/",
+	]);
+	assert.deepEqual(calls.transports[0].resolve, {
+		"example.test": ["203.0.113.10"],
+		"proxy.example": ["203.0.113.20"],
+	});
+});
+
+test("rejects a declared body larger than the configured input cap", async () => {
+	const { fetchPage, calls } = runtime({
+		request: async (url, init) => {
+			calls.requests.push({ url, init });
+			return response({
+				url,
+				headers: {
+					"content-type": "text/plain",
+					"content-length": String(DEFAULT_MAX_RESPONSE_BYTES + 1),
+				},
+				body: "small lie",
+			});
+		},
+	});
+	const result = await fetchPage("https://example.test/");
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "response_too_large");
+	assert.equal(calls.closed, 1);
+});
+
+test("stops an undeclared stream when it crosses the input cap", async () => {
+	let cancelled = false;
+	const body = {
+		getReader() {
+			let reads = 0;
+			return {
+				async read() {
+					reads += 1;
+					if (reads <= 2) return { done: false, value: new Uint8Array(6) };
+					return { done: true };
+				},
+				async cancel() {
+					cancelled = true;
+				},
+			};
+		},
+	};
+	const { fetchPage } = runtime({
+		request: async (url) => ({
+			...response({ url, headers: { "content-type": "text/plain" } }),
+			body,
+		}),
+	});
+	const result = await fetchPage("https://example.test/", {
+		maxResponseBytes: 10,
+	});
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "response_too_large");
+	assert.equal(cancelled, true);
+});
+
+test("applies the input cap across client-side redirect responses", async () => {
+	const firstBody = '<meta http-equiv="refresh" content="0; url=/next">';
+	const responses = [
+		response({
+			url: "https://example.test/start",
+			headers: { "content-type": "text/html" },
+			body: firstBody,
+		}),
+		response({
+			url: "https://example.test/next",
+			headers: { "content-type": "text/plain" },
+			body: "more than four bytes",
+		}),
+	];
+	const { fetchPage } = runtime({ request: async () => responses.shift() });
+	const result = await fetchPage("https://example.test/start", {
+		maxResponseBytes: encoder.encode(firstBody).byteLength + 4,
+	});
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "response_too_large");
+});
+
+test("charges failed partial streams against the retry byte budget", async () => {
+	let attempts = 0;
+	const { fetchPage, calls } = runtime({
+		request: async (url, init) => {
+			calls.requests.push({ url, init });
+			attempts += 1;
+			let reads = 0;
+			return {
+				...response({ url, headers: { "content-type": "text/plain" } }),
+				body: {
+					getReader() {
+						return {
+							async read() {
+								reads += 1;
+								if (reads === 1) {
+									return {
+										done: false,
+										value: encoder.encode(attempts === 1 ? "12345678" : "123"),
+									};
+								}
+								if (attempts === 1) {
+									throw Object.assign(new Error("reset"), { code: "ECONNRESET" });
+								}
+								return { done: true, value: undefined };
+							},
+							async cancel() {},
+						};
+					},
+				},
+			};
+		},
+	});
+	const result = await fetchPage("https://example.test/", {
+		format: "raw",
+		maxResponseBytes: 10,
+		maxRetries: 1,
+	});
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "response_too_large");
+	assert.equal(calls.requests.length, 2);
+});
+
+test("returns an aborted result before opening a transport", async () => {
+	const controller = new AbortController();
+	controller.abort();
+	const { fetchPage, calls } = runtime();
+	const result = await fetchPage("https://example.test/", {
+		signal: controller.signal,
+	});
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "aborted");
+	assert.deepEqual(calls.transports, []);
+});
+
+test("closes a transport that finishes creating after cancellation", async () => {
+	let resolveTransport;
+	let closed = 0;
+	const transport = {
+		async close() {
+			closed += 1;
+		},
+	};
+	const { fetchPage, calls } = runtime({
+		createTransport: () =>
+			new Promise((resolve) => {
+				resolveTransport = resolve;
+			}),
+	});
+	const controller = new AbortController();
+	const pending = fetchPage("https://example.test/", {
+		signal: controller.signal,
+	});
+	while (!resolveTransport) await new Promise((resolve) => setTimeout(resolve, 0));
+	controller.abort();
+	const result = await pending;
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "aborted");
+	resolveTransport(transport);
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	assert.equal(closed, 1);
+});
+
+test("the call timeout bounds a hanging transport close", async () => {
+	const { fetchPage } = runtime({
+		createTransport: async () => ({ close: () => new Promise(() => {}) }),
+	});
+	const startedAt = Date.now();
+	const result = await fetchPage("https://example.test/", {
+		format: "raw",
+		timeoutMs: 5,
+	});
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "timeout");
+	assert.ok(Date.now() - startedAt < 100);
+});
+
+test("cancels a response that arrives after cancellation", async () => {
+	let resolveRequest;
+	let cancelled = false;
+	const lateResponse = response({
+		url: "https://example.test/",
+		headers: { "content-type": "text/plain" },
+		body: "late",
+	});
+	lateResponse.body = {
+		getReader: lateResponse.body.getReader.bind(lateResponse.body),
+		async cancel() {
+			cancelled = true;
+		},
+	};
+	const { fetchPage } = runtime({
+		request: () =>
+			new Promise((resolve) => {
+				resolveRequest = resolve;
+			}),
+	});
+	const controller = new AbortController();
+	const pending = fetchPage("https://example.test/", {
+		signal: controller.signal,
+	});
+	while (!resolveRequest) await new Promise((resolve) => setTimeout(resolve, 0));
+	controller.abort();
+	const result = await pending;
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "aborted");
+	resolveRequest(lateResponse);
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	assert.equal(cancelled, true);
+});
+
+test("cancels a pending body read and closes the transport", async () => {
+	let cancelled = false;
+	const body = {
+		getReader() {
+			return {
+				read: () => new Promise(() => {}),
+				async cancel() {
+					cancelled = true;
+				},
+			};
+		},
+	};
+	const { fetchPage, calls } = runtime({
+		request: async (url) => ({
+			...response({ url, headers: { "content-type": "text/plain" } }),
+			body,
+		}),
+	});
+	const controller = new AbortController();
+	const pending = fetchPage("https://example.test/", {
+		signal: controller.signal,
+	});
+	setTimeout(() => controller.abort(), 5);
+	const result = await pending;
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "aborted");
+	assert.equal(cancelled, true);
+	assert.equal(calls.closed, 1);
+});
+
+test("destroys a PDF parser when extraction is cancelled", async () => {
+	let parserStarted = false;
+	let destroyed = 0;
+	class FakePdfParser {
+		constructor() {}
+		load() {
+			parserStarted = true;
+			return new Promise(() => {});
+		}
+		async getText() {
+			return { text: "", total: 0 };
+		}
+		async destroy() {
+			destroyed += 1;
+		}
+	}
+	const { fetchPage } = runtime({
+		request: async (url) =>
+			response({
+				url,
+				headers: { "content-type": "application/pdf" },
+				body: encoder.encode("%PDF-test"),
+			}),
+		loadPdfParser: async () => FakePdfParser,
+	});
+	const controller = new AbortController();
+	const pending = fetchPage("https://example.test/file.pdf", {
+		signal: controller.signal,
+	});
+	while (!parserStarted) await new Promise((resolve) => setTimeout(resolve, 0));
+	controller.abort();
+	const result = await pending;
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "aborted");
+	assert.equal(destroyed, 1);
+});
+
+test("detects a mislabeled PDF and destroys the parser after success", async () => {
+	let destroyed = 0;
+	class FakePdfParser {
+		constructor() {}
+		async load() {}
+		async getText() {
+			return { text: "PDF body text", total: 1 };
+		}
+		async destroy() {
+			destroyed += 1;
+		}
+	}
+	const { fetchPage } = runtime({
+		request: async (url) =>
+			response({
+				url,
+				headers: { "content-type": "text/plain" },
+				body: encoder.encode("%PDF-test"),
+			}),
+		loadPdfParser: async () => FakePdfParser,
+	});
+	const result = await fetchPage("https://example.test/file.pdf", {
+		format: "text",
+	});
+	assert.equal(result.ok, true);
+	assert.equal(result.content, "PDF body text");
+	assert.equal(result.contentType, "application/pdf");
+	assert.equal(destroyed, 1);
+});
+
+test("closes a failed attempt before retry backoff", async () => {
+	const responses = [
+		response({ url: "https://example.test/", status: 503 }),
+		response({
+			url: "https://example.test/",
+			headers: { "content-type": "text/plain" },
+			body: "recovered",
+		}),
+	];
+	const events = [];
+	const { fetchPage, calls } = runtime({
+		createTransport: async (options) => {
+			calls.transports.push(options);
+			return {
+				async close() {
+					calls.closed += 1;
+					events.push("close");
+				},
+			};
+		},
+		request: async (url, init) => {
+			calls.requests.push({ url, init });
+			return responses.shift();
+		},
+		sleep: async (ms) => {
+			calls.sleeps.push(ms);
+			events.push("sleep");
+		},
+	});
+	const result = await fetchPage("https://example.test/", {
+		format: "raw",
+		maxRetries: 1,
+	});
+	assert.equal(result.ok, true);
+	assert.equal(result.content, "recovered");
+	assert.equal(calls.requests.length, 2);
+	assert.equal(calls.transports.length, 2);
+	assert.equal(calls.closed, 2);
+	assert.equal(calls.sleeps.length, 1);
+	assert.deepEqual(events.slice(0, 2), ["close", "sleep"]);
+});
+
+test("extracts markdown locally and forwards image and reply controls", async () => {
+	const html = `<!doctype html><html lang="en"><head>
+		<title>Example article</title>
+		<meta name="author" content="A. Writer">
+	</head><body><main><article><h1>Example article</h1>
+		<p>This paragraph contains enough useful words for a stable extraction result in the local test.</p>
+		<img src="https://example.test/image.png" alt="diagram">
+	</article></main></body></html>`;
+	const { fetchPage } = runtime({
+		request: async (url) =>
+			response({ url, headers: { "content-type": "text/html" }, body: html }),
+	});
+	const result = await fetchPage("https://example.test/article", {
+		removeImages: true,
+		includeReplies: false,
+	});
+	assert.equal(result.ok, true);
+	assert.equal(result.format, "markdown");
+	assert.equal(result.title, "Example article");
+	assert.match(result.content, /enough useful words/);
+	assert.doesNotMatch(result.content, /image\.png|diagram/);
+	assert.equal(result.browserEscalated, false);
+	assert.equal(result.remoteFallbackUsed, false);
+	assert.equal(result.persisted, false);
+});
+
+test("prevents Defuddle site extractors from opening additional network requests", async () => {
+	const originalFetch = globalThis.fetch;
+	let unexpectedRequests = 0;
+	globalThis.fetch = async () => {
+		unexpectedRequests += 1;
+		throw new Error("unexpected global fetch");
+	};
+	try {
+		const html = `<!doctype html><html><head><title>Post</title></head><body>
+			<main><h1>Post</h1><p>Locally supplied fallback content remains readable.</p></main>
+		</body></html>`;
+		const { fetchPage } = runtime({
+			request: async () =>
+				response({
+					url: "https://x.com/user/status/123",
+					headers: { "content-type": "text/html" },
+					body: html,
+				}),
+		});
+		const result = await fetchPage("https://x.com/user/status/123");
+		assert.equal(result.ok, true);
+		assert.match(result.content, /fallback content/);
+		assert.equal(unexpectedRequests, 0);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("supports raw, JSON, text, and cleaned HTML output", async () => {
+	const jsonBody = '{"ok":true,"items":[1,2]}';
+	const jsonRuntime = runtime({
+		request: async (url) =>
+			response({
+				url,
+				headers: { "content-type": "application/json" },
+				body: jsonBody,
+			}),
+	});
+	const raw = await jsonRuntime.fetchPage("https://example.test/data", {
+		format: "raw",
+	});
+	assert.equal(raw.ok, true);
+	assert.equal(raw.content, jsonBody);
+
+	const json = await jsonRuntime.fetchPage("https://example.test/data", {
+		format: "json",
+	});
+	assert.equal(json.ok, true);
+	assert.equal(json.content, '{\n  "ok": true,\n  "items": [\n    1,\n    2\n  ]\n}');
+
+	const htmlBody = "<html><head><title>T</title></head><body><main><h1>Heading</h1><p>Readable body.</p></main></body></html>";
+	const htmlRuntime = runtime({
+		request: async (url) =>
+			response({ url, headers: { "content-type": "text/html" }, body: htmlBody }),
+	});
+	const text = await htmlRuntime.fetchPage("https://example.test/page", {
+		format: "text",
+	});
+	assert.equal(text.ok, true);
+	assert.match(text.content, /Heading/);
+	assert.doesNotMatch(text.content, /<h1>/i);
+
+	const html = await htmlRuntime.fetchPage("https://example.test/page", {
+		format: "html",
+	});
+	assert.equal(html.ok, true);
+	assert.match(html.content, /<H2>Heading<\/H2>|<h2>Heading<\/h2>/);
+});
+
+test("enforces format behavior across JSON, XML, text, and binary MIME types", async () => {
+	const plainRuntime = runtime({
+		request: async (url) =>
+			response({ url, headers: { "content-type": "text/plain" }, body: "plain" }),
+	});
+	const htmlFromText = await plainRuntime.fetchPage("https://example.test/plain", {
+		format: "html",
+	});
+	assert.equal(htmlFromText.ok, false);
+	assert.equal(htmlFromText.error.code, "unexpected_content_type");
+
+	const xmlRuntime = runtime({
+		request: async (url) =>
+			response({
+				url,
+				headers: { "content-type": "application/xml" },
+				body: "<root><value>Readable XML</value></root>",
+			}),
+	});
+	const xmlText = await xmlRuntime.fetchPage("https://example.test/data.xml", {
+		format: "text",
+	});
+	assert.equal(xmlText.ok, true);
+	assert.equal(xmlText.content, "Readable XML");
+
+	const latinRuntime = runtime({
+		request: async (url) =>
+			response({
+				url,
+				headers: { "content-type": "text/plain; charset=iso-8859-1" },
+				body: new Uint8Array([0x63, 0x61, 0x66, 0xe9]),
+			}),
+	});
+	const latin = await latinRuntime.fetchPage("https://example.test/latin", {
+		format: "raw",
+	});
+	assert.equal(latin.ok, true);
+	assert.equal(latin.content, "café");
+
+	const invalidJsonRuntime = runtime({
+		request: async (url) =>
+			response({
+				url,
+				headers: { "content-type": "application/json" },
+				body: "{",
+			}),
+	});
+	const invalidJson = await invalidJsonRuntime.fetchPage(
+		"https://example.test/data",
+		{ format: "json" },
+	);
+	assert.equal(invalidJson.ok, false);
+	assert.equal(invalidJson.error.code, "parse_error");
+
+	for (const headers of [
+		{ "content-type": "application/octet-stream" },
+		{ "content-type": "text/plain" },
+		{},
+	]) {
+		const binaryRuntime = runtime({
+			request: async (url) =>
+				response({
+					url,
+					headers,
+					body: new Uint8Array([0, 1, 2, 0xff]),
+				}),
+		});
+		const binary = await binaryRuntime.fetchPage("https://example.test/file", {
+			format: "raw",
+		});
+		assert.equal(binary.ok, false, JSON.stringify(headers));
+		assert.equal(binary.error.code, "binary_content");
+	}
+});
+
+test("redacts encoded and low-entropy credentials from successful URL metadata", async () => {
+	for (const secretUrl of [
+		"https://example.test/path?token=%61%42%63%31%32%33",
+		"https://example.test/path?%74oken=abc",
+		"https://example.test/path?access_token=abc",
+		"https://example.test/path?refresh_token=abc",
+		"https://example.test/path?id_token=abc",
+		"https://example.test/path#section?token=abc",
+	]) {
+		const { fetchPage } = runtime({
+			request: async () =>
+				response({
+					url: secretUrl,
+					headers: { "content-type": "text/plain" },
+					body: "ok",
+				}),
+		});
+		const result = await fetchPage(secretUrl, { format: "raw" });
+		assert.equal(result.ok, true, secretUrl);
+		assert.doesNotMatch(
+			result.url,
+			/%61%42%63|%74oken|(?:access_|refresh_|id_)?token=abc/i,
+		);
+		assert.doesNotMatch(
+			result.finalUrl,
+			/%61%42%63|%74oken|(?:access_|refresh_|id_)?token=abc/i,
+		);
+	}
+});
+
+test("redacts credential-like redirect URLs from successful metadata", async () => {
+	const redirected = "https://b.example/final?token=aBcd1234-ZYX9876";
+	const responses = [
+		response({
+			url: "https://a.example/start",
+			status: 302,
+			headers: { location: redirected },
+		}),
+		response({
+			url: redirected,
+			headers: { "content-type": "text/plain" },
+			body: "ok",
+		}),
+	];
+	const { fetchPage } = runtime({ request: async () => responses.shift() });
+	const result = await fetchPage("https://a.example/start", { format: "raw" });
+	assert.equal(result.ok, true);
+	assert.doesNotMatch(result.finalUrl, /aBcd1234-ZYX9876/);
+	assert.doesNotMatch(result.redirects[0], /aBcd1234-ZYX9876/);
+});
+
+test("redacts malformed secret-bearing URLs from fields and errors", async () => {
+	const { fetchPage } = runtime();
+	const result = await fetchPage("https://[bad]/?foo=1;access_token=abc");
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "invalid_url");
+	assert.doesNotMatch(result.url, /access_token=abc/);
+	assert.doesNotMatch(result.error.message, /access_token=abc/);
+});
+
+test("redacts secret-bearing URLs embedded in transport errors", async () => {
+	const { fetchPage } = runtime({
+		request: async () => {
+			throw new Error("Request failed for https://example.test/?access_token=abc");
+		},
+	});
+	const result = await fetchPage("https://example.test/");
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "network_error");
+	assert.doesNotMatch(result.error.message, /access_token=abc/);
+});
+
+test("redacts secret-bearing URLs from validation failures", async () => {
+	const { fetchPage, calls } = runtime();
+	const result = await fetchPage("https://user:secret-value@example.test/path");
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "blocked_secret");
+	assert.doesNotMatch(result.url, /secret-value/);
+	assert.equal(calls.requests.length, 0);
+});
+
+test("accepts every public wreq browser alias", async () => {
+	for (const browser of [
+		"chrome",
+		"edge",
+		"firefox",
+		"firefox_android",
+		"firefox_private",
+		"okhttp",
+		"opera",
+		"safari",
+		"safari_ios",
+		"safari_ipad",
+	]) {
+		const { fetchPage } = runtime();
+		const result = await fetchPage("https://example.test/", {
+			browser,
+			format: "raw",
+		});
+		assert.equal(result.ok, true, browser);
+	}
+});
+
+test("rejects invalid resource limits before network work", async () => {
+	const { fetchPage, calls } = runtime();
+	const result = await fetchPage("https://example.test/", { maxResponseBytes: 0 });
+	assert.equal(result.ok, false);
+	assert.equal(result.error.code, "invalid_option");
+	assert.deepEqual(calls.validated, []);
+	assert.deepEqual(calls.transports, []);
+
+	const invalidUrl = await fetchPage(12345);
+	assert.equal(invalidUrl.ok, false);
+	assert.equal(invalidUrl.error.code, "invalid_url");
+	for (const invalidOptions of [
+		null,
+		[],
+		{ headers: ["bad"] },
+		{ headers: { "X-Bad\nName": "value" } },
+		{ headers: { "X-Test": "ok\r\nInjected: yes" } },
+		{ headers: { Host: "attacker.test" } },
+		{ headers: { "Content-Length": "1" } },
+		{ proxy: 123 },
+		{ unexpected: true },
+		{ format: "xml" },
+		{ browser: "netscape_4" },
+		{ browser: "chrome_999" },
+		{ os: "plan9" },
+		{ removeImages: "yes" },
+		{ includeReplies: "all" },
+		{ signal: { aborted: false, addEventListener() {} } },
+	]) {
+		const invalid = await fetchPage("https://example.test/", invalidOptions);
+		assert.equal(invalid.ok, false, JSON.stringify(invalidOptions));
+		assert.equal(invalid.error.code, "invalid_option");
+	}
+	assert.deepEqual(calls.validated, []);
+});
+
+test("applies the caller's output bound without writing content state", async () => {
+	const { fetchPage } = runtime({
+		request: async (url) =>
+			response({
+				url,
+				headers: { "content-type": "text/plain" },
+				body: "one two three",
+			}),
+	});
+	const result = await fetchPage("https://example.test/", {
+		format: "raw",
+		maxChars: 5,
+	});
+	assert.equal(result.ok, true);
+	assert.equal(result.content, "one t");
+	assert.equal(result.truncated, true);
+	assert.equal(result.wordCount, 3);
+	assert.equal(result.fullContentChars, 13);
+	assert.equal(result.outputChars, 5);
+	assert.equal(result.persisted, false);
+});
+
+test("the supported entrypoint has no browser, search, remote-reader, or storage imports", async () => {
+	const source = [
+		await readFile(new URL("../src/webfetch.ts", import.meta.url), "utf8"),
+		await readFile(new URL("../src/webfetch-api.ts", import.meta.url), "utf8"),
+	].join("\n");
+	assert.doesNotMatch(
+		source,
+		/from ["']\.\/(?:browser|search|fetch-jina|session-store|storage|tools\/webfetch)/,
+	);
+	assert.doesNotMatch(source, /node:fs/);
+
+	const manifest = JSON.parse(
+		await readFile(new URL("../package.json", import.meta.url), "utf8"),
+	);
+	assert.deepEqual(manifest.exports["./webfetch"], {
+		types: "./dist/src/webfetch.d.ts",
+		import: "./dist/src/webfetch.js",
+	});
+});

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"rootDir": ".",
 		"outDir": "./dist",
-		"declaration": false,
+		"declaration": true,
 		"sourceMap": false,
 		"noEmit": false,
 		"rewriteRelativeImportExtensions": true,


### PR DESCRIPTION
## Summary

- Add `pi-webaio/webfetch`, a supported browser-free API for fingerprinted HTTP fetches and local Defuddle/PDF extraction.
- Validate and DNS-pin every direct destination and redirect hop, deny non-public special-purpose address ranges, and redact credentials from returned URL metadata and errors.
- Propagate cancellation, bound the whole call and cleanup, cap aggregate retry and redirect input at 10 MiB, and support Markdown, cleaned HTML, text, JSON, and raw textual output.
- Publish JavaScript and TypeScript declarations and verify the packed entrypoint without Playwright or Pi peer packages.

## Intended boundary

The new entrypoint does not register tools, start a browser, contact a remote reader, or write a content cache. JavaScript rendering and search remain separate integrations. Proxy modes that resolve the target independently report `targetPinning: "proxy-dependent"`.

The branch also fixes the stale Defuddle timeout assertion that prevented the v1.0.5 platform jobs from running.

## Validation

- `npm run test:webfetch-api` — 34 passed
- `npm run test:webfetch-package` — passed
- `npm run test:ssrf` — 84 passed
- `npm run test:ssrf-allowlist` — 37 passed
- `npm run lint` — passed
- `npm run build:dist` — passed
- `npm run check:lockfile` — passed
- `PI_WEBAIO_SHARED_BROWSER_POOL=0 npm run test:all` — 1,472 passed, two skipped, zero failed
- Live static fetch of `https://example.com` — passed
